### PR TITLE
[codex] Add Pro stats tab

### DIFF
--- a/BeanBook/App/RootTabView.swift
+++ b/BeanBook/App/RootTabView.swift
@@ -7,7 +7,7 @@ struct RootTabView: View {
     @State private var showAddBrew = false
 
     enum TabSelection: Hashable {
-        case today, beans, recipes, add
+        case today, beans, stats, shop, add
     }
 
     var body: some View {
@@ -18,8 +18,11 @@ struct RootTabView: View {
             Tab("Beans", systemImage: "bag.fill", value: TabSelection.beans) {
                 NavigationStack { BagListView() }
             }
-            Tab("Recipes", systemImage: "list.bullet", value: TabSelection.recipes) {
-                NavigationStack { RecipesView() }
+            Tab("Stats", systemImage: "waveform.path.ecg", value: TabSelection.stats) {
+                NavigationStack { StatsView() }
+            }
+            Tab("Shop", systemImage: "sparkles", value: TabSelection.shop) {
+                NavigationStack { ShopView() }
             }
             Tab(value: TabSelection.add, role: .search) {
                 Color.clear

--- a/BeanBook/Features/Brews/BrewListView.swift
+++ b/BeanBook/Features/Brews/BrewListView.swift
@@ -7,8 +7,10 @@ struct BrewListView: View {
     @Environment(\.modelContext) private var context
     @Environment(\.dismiss) private var dismiss
     @Query(sort: \Brew.createdAt, order: .reverse) private var brews: [Brew]
+    @Query(sort: \BrewPreset.createdAt, order: .reverse) private var presets: [BrewPreset]
 
     @State private var showAddSheet = false
+    @State private var showRecipes = false
     @State private var hotStartBrew: Brew?
     @Namespace private var addSheetNamespace
 
@@ -29,6 +31,11 @@ struct BrewListView: View {
                                 hotStartBrew = brew
                             }
                             .padding(.top, 24)
+                        }
+                        if !presets.isEmpty {
+                            savedRecipesEntry
+                                .padding(.horizontal, 24)
+                                .padding(.top, recentBrews.count > 1 ? 22 : 24)
                         }
                         list
                         Spacer().frame(height: 80)
@@ -59,6 +66,9 @@ struct BrewListView: View {
             NewBrewSheet()
                 .navigationTransition(.zoom(sourceID: "addBrew", in: addSheetNamespace))
         }
+        .sheet(isPresented: $showRecipes) {
+            NavigationStack { RecipesView() }
+        }
         .sheet(item: $hotStartBrew) { brew in
             NewBrewSheet(prefill: brew)
         }
@@ -75,6 +85,36 @@ struct BrewListView: View {
                 .foregroundStyle(Theme.ink)
         }
         .padding(.horizontal, 24)
+    }
+
+    private var savedRecipesEntry: some View {
+        Button {
+            showRecipes = true
+        } label: {
+            VStack(spacing: 0) {
+                HairRule()
+                HStack {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Eyebrow("\(presets.count) saved")
+                        Text("Saved recipes")
+                            .font(.system(size: 22, weight: .medium, design: .serif))
+                            .tracking(-0.4)
+                            .foregroundStyle(Theme.ink)
+                        Text("Repeat what worked.")
+                            .font(Theme.body(12))
+                            .foregroundStyle(Theme.ink2)
+                    }
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(Theme.ink3)
+                }
+                .padding(.vertical, 16)
+                HairRule()
+            }
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
     }
 
     private var list: some View {

--- a/BeanBook/Features/Stats/StatsSummary.swift
+++ b/BeanBook/Features/Stats/StatsSummary.swift
@@ -1,0 +1,274 @@
+import Foundation
+import SwiftData
+
+struct StatsSummary {
+    struct DailyCount: Identifiable, Equatable {
+        let id: Date
+        let date: Date
+        let count: Int
+    }
+
+    struct BagSummary: Identifiable, Equatable {
+        let id: PersistentIdentifier
+        let title: String
+        let brewCount: Int
+        let averageRating: Double?
+        let lastBrewedAt: Date
+        let methodLabel: String
+        let ratioLabel: String
+    }
+
+    struct BrewRow: Identifiable, Equatable {
+        let id: PersistentIdentifier
+        let brewID: PersistentIdentifier
+        let title: String
+        let detail: String
+        let ratioLabel: String
+        let rating: Int?
+        let createdAt: Date
+    }
+
+    struct DialInRow: Identifiable, Equatable {
+        let id: PersistentIdentifier
+        let brewID: PersistentIdentifier
+        let detail: String
+        let rating: Int?
+        let createdAt: Date
+    }
+
+    let windowStart: Date
+    let windowEnd: Date
+    let totalBrews: Int
+    let totalLifetimeBrews: Int
+    let activeBagCount: Int
+    let favoriteMethod: BrewMethod?
+    let averageRating: Double?
+    let dailyCounts: [DailyCount]
+    let workingBrews: [BrewRow]
+    let bestBag: BagSummary?
+    let bestRecipeName: String?
+    let bagSummaries: [BagSummary]
+    let dialInBagTitle: String?
+    let dialInRows: [DialInRow]
+    let loggedSoFar: [BrewRow]
+
+    var isSparse: Bool { totalBrews < 3 }
+}
+
+extension StatsSummary {
+    static func build(
+        brews: [Brew],
+        bags: [Bag],
+        presets: [BrewPreset],
+        now: Date = .now,
+        calendar: Calendar = .current
+    ) -> StatsSummary {
+        let end = now
+        let startOfToday = calendar.startOfDay(for: now)
+        let start = calendar.date(byAdding: .day, value: -29, to: startOfToday) ?? startOfToday
+        let sorted = brews.sorted { $0.createdAt > $1.createdAt }
+        let windowBrews = sorted.filter { $0.createdAt >= start && $0.createdAt <= end }
+        let rated = windowBrews.compactMap(\.rating).filter { $0 > 0 }
+        let activeBags = Set(windowBrews.compactMap { $0.bag?.persistentModelID })
+        let dialInBag = dialInBag(from: sorted, bags: bags)
+
+        return StatsSummary(
+            windowStart: start,
+            windowEnd: end,
+            totalBrews: windowBrews.count,
+            totalLifetimeBrews: brews.count,
+            activeBagCount: activeBags.count,
+            favoriteMethod: favoriteMethod(in: windowBrews),
+            averageRating: average(rated.map(Double.init)),
+            dailyCounts: dailyCounts(from: windowBrews, start: start, calendar: calendar),
+            workingBrews: workingBrews(from: windowBrews),
+            bestBag: bestBag(from: windowBrews),
+            bestRecipeName: bestRecipeName(from: presets),
+            bagSummaries: bagSummaries(from: windowBrews),
+            dialInBagTitle: dialInBag?.displayTitle,
+            dialInRows: dialInRows(from: sorted, bag: dialInBag),
+            loggedSoFar: Array(sorted.prefix(5)).map(BrewRow.init)
+        )
+    }
+
+    private static func favoriteMethod(in brews: [Brew]) -> BrewMethod? {
+        guard brews.count >= 3 else { return nil }
+        let counts = Dictionary(grouping: brews, by: \.method).mapValues(\.count)
+        return counts.sorted { lhs, rhs in
+            if lhs.value == rhs.value {
+                return lhs.key.displayName < rhs.key.displayName
+            }
+            return lhs.value > rhs.value
+        }.first?.key
+    }
+
+    private static func dailyCounts(
+        from brews: [Brew],
+        start: Date,
+        calendar: Calendar
+    ) -> [DailyCount] {
+        let grouped = Dictionary(grouping: brews) { calendar.startOfDay(for: $0.createdAt) }
+        return (0..<30).compactMap { offset in
+            guard let day = calendar.date(byAdding: .day, value: offset, to: start) else {
+                return nil
+            }
+            return DailyCount(id: day, date: day, count: grouped[day, default: []].count)
+        }
+    }
+
+    private static func workingBrews(from brews: [Brew]) -> [BrewRow] {
+        brews
+            .filter { ($0.rating ?? 0) > 0 }
+            .sorted { lhs, rhs in
+                if lhs.rating == rhs.rating {
+                    return lhs.createdAt > rhs.createdAt
+                }
+                return (lhs.rating ?? 0) > (rhs.rating ?? 0)
+            }
+            .prefix(3)
+            .map(BrewRow.init)
+    }
+
+    private static func bagSummaries(from brews: [Brew]) -> [BagSummary] {
+        let grouped = Dictionary(grouping: brews.compactMap { brew -> (Bag, Brew)? in
+            guard let bag = brew.bag else { return nil }
+            return (bag, brew)
+        }) { pair in
+            pair.0.persistentModelID
+        }
+
+        return grouped.values.compactMap { pairs in
+            guard let bag = pairs.first?.0 else { return nil }
+            let bagBrews = pairs.map(\.1)
+            return BagSummary(bag: bag, brews: bagBrews)
+        }
+        .sorted { lhs, rhs in
+            lhs.lastBrewedAt > rhs.lastBrewedAt
+        }
+    }
+
+    private static func bestBag(from brews: [Brew]) -> BagSummary? {
+        bagSummaries(from: brews)
+            .filter { $0.brewCount >= 3 && $0.averageRating != nil }
+            .sorted { lhs, rhs in
+                if lhs.averageRating == rhs.averageRating {
+                    return lhs.brewCount > rhs.brewCount
+                }
+                return (lhs.averageRating ?? 0) > (rhs.averageRating ?? 0)
+            }
+            .first
+    }
+
+    private static func bestRecipeName(from presets: [BrewPreset]) -> String? {
+        presets
+            .sorted { $0.createdAt > $1.createdAt }
+            .map(\.name)
+            .first { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+    }
+
+    private static func dialInBag(from brews: [Brew], bags: [Bag]) -> Bag? {
+        if let pinned = bags.first(where: \.isPinned) {
+            return pinned
+        }
+        return brews.first?.bag
+    }
+
+    private static func dialInRows(from brews: [Brew], bag: Bag?) -> [DialInRow] {
+        guard let bag else { return [] }
+        return brews
+            .filter { brew in
+                brew.method == .espresso && brew.bag?.persistentModelID == bag.persistentModelID
+            }
+            .prefix(5)
+            .map(DialInRow.init)
+    }
+
+    private static func average(_ values: [Double]) -> Double? {
+        guard !values.isEmpty else { return nil }
+        let raw = values.reduce(0, +) / Double(values.count)
+        return (raw * 10).rounded() / 10
+    }
+}
+
+extension StatsSummary.BagSummary {
+    init(bag: Bag, brews: [Brew]) {
+        let sorted = brews.sorted { $0.createdAt > $1.createdAt }
+        let rated = brews.compactMap(\.rating).filter { $0 > 0 }.map(Double.init)
+        let methodCounts = Dictionary(grouping: brews, by: \.method).mapValues(\.count)
+        let method = methodCounts.sorted { lhs, rhs in
+            if lhs.value == rhs.value {
+                return lhs.key.displayName < rhs.key.displayName
+            }
+            return lhs.value > rhs.value
+        }.first?.key
+
+        self.id = bag.persistentModelID
+        self.title = bag.displayTitle
+        self.brewCount = brews.count
+        self.averageRating = Self.average(rated)
+        self.lastBrewedAt = sorted.first?.createdAt ?? bag.createdAt
+        self.methodLabel = method?.displayName ?? "More data needed"
+        self.ratioLabel = Self.averageRatio(from: brews)
+    }
+
+    private static func average(_ values: [Double]) -> Double? {
+        guard !values.isEmpty else { return nil }
+        let raw = values.reduce(0, +) / Double(values.count)
+        return (raw * 10).rounded() / 10
+    }
+
+    private static func averageRatio(from brews: [Brew]) -> String {
+        let ratios = brews.map(\.ratio).filter { $0 > 0 }
+        guard !ratios.isEmpty else { return "-" }
+        let average = ratios.reduce(0, +) / Double(ratios.count)
+        return "1:\(average.formatted(.number.precision(.fractionLength(2))))"
+    }
+}
+
+extension StatsSummary.BrewRow {
+    init(_ brew: Brew) {
+        self.id = brew.persistentModelID
+        self.brewID = brew.persistentModelID
+        self.title = brew.method.displayName
+        self.detail = Self.detail(for: brew)
+        self.ratioLabel = brew.formattedRatio
+        self.rating = brew.rating
+        self.createdAt = brew.createdAt
+    }
+
+    private static func detail(for brew: Brew) -> String {
+        let date = brew.createdAt.formatted(date: .abbreviated, time: .omitted)
+        if let bag = brew.bag?.brand, !bag.isEmpty {
+            return "\(bag) / \(date)"
+        }
+        return date
+    }
+}
+
+extension StatsSummary.DialInRow {
+    init(_ brew: Brew) {
+        self.id = brew.persistentModelID
+        self.brewID = brew.persistentModelID
+        self.detail = Self.detail(for: brew)
+        self.rating = brew.rating
+        self.createdAt = brew.createdAt
+    }
+
+    private static func detail(for brew: Brew) -> String {
+        var parts = [
+            "\(Self.numeric(brew.doseGrams))g -> \(Self.numeric(brew.yieldGrams))g",
+            brew.formattedTime
+        ]
+        if let grind = brew.grindSetting, !grind.isEmpty {
+            parts.append(grind)
+        }
+        return parts.joined(separator: " / ")
+    }
+
+    private static func numeric(_ value: Double) -> String {
+        if value.truncatingRemainder(dividingBy: 1) == 0 {
+            return String(Int(value))
+        }
+        return value.formatted(.number.precision(.fractionLength(1)))
+    }
+}

--- a/BeanBook/Features/Stats/StatsView.swift
+++ b/BeanBook/Features/Stats/StatsView.swift
@@ -1,0 +1,572 @@
+import SwiftUI
+import SwiftData
+
+struct StatsView: View {
+    @Environment(ProEntitlement.self) private var pro
+    @Query(sort: \Brew.createdAt, order: .reverse) private var brews: [Brew]
+    @Query(sort: \Bag.createdAt, order: .reverse) private var bags: [Bag]
+    @Query(sort: \BrewPreset.createdAt, order: .reverse) private var presets: [BrewPreset]
+
+    @State private var showPaywall = false
+    @State private var showAddBrew = false
+
+    private var summary: StatsSummary {
+        StatsSummary.build(brews: brews, bags: bags, presets: presets)
+    }
+
+    var body: some View {
+        ZStack {
+            Theme.background.ignoresSafeArea()
+
+            if !pro.isPro {
+                lockedState
+            } else if brews.isEmpty {
+                noBrewsState
+            } else if summary.isSparse {
+                sparseState
+            } else {
+                populatedState
+            }
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(.hidden, for: .navigationBar)
+        .sheet(isPresented: $showPaywall) {
+            PaywallSheet(headline: "Stats are included with BeanBook Pro.")
+        }
+        .sheet(isPresented: $showAddBrew) {
+            NewBrewSheet()
+        }
+    }
+
+    private var lockedState: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                Eyebrow("BeanBook Pro")
+                    .padding(.top, 12)
+
+                Text("Stats")
+                    .font(.system(size: 42, weight: .medium, design: .serif))
+                    .tracking(-1.2)
+                    .foregroundStyle(Theme.ink)
+                    .padding(.top, 28)
+
+                Text("Stats are included with BeanBook Pro - a one-time purchase that also unlocks unlimited bags and exports.")
+                    .font(Theme.body(15))
+                    .foregroundStyle(Theme.ink2)
+                    .lineSpacing(4)
+                    .frame(maxWidth: 320, alignment: .leading)
+                    .padding(.top, 12)
+
+                Eyebrow("What you get")
+                    .padding(.top, 32)
+
+                VStack(spacing: 0) {
+                    StatsProFeatureRow(number: "01", title: "Overview", detail: "Total brews, active bags, favorite method, average rating.")
+                    StatsProFeatureRow(number: "02", title: "What's working", detail: "Highest-rated brews, your best bag, best saved recipe.")
+                    StatsProFeatureRow(number: "03", title: "By bag", detail: "Brew count, average rating, common ratio, last brewed.")
+                    StatsProFeatureRow(number: "04", title: "Dial-in", detail: "Espresso shot history with grind and rating changes.", showsRule: false)
+                }
+                .padding(.top, 16)
+
+                Button {
+                    showPaywall = true
+                } label: {
+                    HStack(spacing: 10) {
+                        Text("Unlock Pro once")
+                        Image(systemName: "arrow.right")
+                            .font(.system(size: 13, weight: .medium))
+                    }
+                }
+                .buttonStyle(.accentPill)
+                .padding(.top, 36)
+
+                Text("One-time purchase. No subscription. Family Sharing supported.")
+                    .font(Theme.body(12, weight: .medium))
+                    .foregroundStyle(Theme.ink2)
+                    .padding(.top, 16)
+
+                Spacer().frame(height: 80)
+            }
+            .padding(.horizontal, 24)
+        }
+        .scrollIndicators(.hidden)
+    }
+
+    private var noBrewsState: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Eyebrow("Stats")
+                .padding(.top, 12)
+
+            Text("\(Text("Nothing\nto show\n").foregroundStyle(Theme.ink))\(Text("yet.").foregroundStyle(Theme.accent))")
+                .font(.system(size: 42, weight: .medium, design: .serif))
+                .tracking(-1.2)
+                .lineSpacing(1)
+                .padding(.top, 56)
+
+            Text("Log your first brew and patterns will start to appear here - what's working, by bag, dial-in.")
+                .font(Theme.body(15))
+                .foregroundStyle(Theme.ink2)
+                .lineSpacing(4)
+                .frame(maxWidth: 300, alignment: .leading)
+                .padding(.top, 28)
+
+            Button {
+                showAddBrew = true
+            } label: {
+                HStack(spacing: 10) {
+                    Text("Log a brew")
+                    Image(systemName: "arrow.right")
+                        .font(.system(size: 13, weight: .medium))
+                }
+            }
+            .buttonStyle(.accentPill)
+            .padding(.top, 36)
+
+            Spacer()
+        }
+        .padding(.horizontal, 32)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var sparseState: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                statsHeader
+                StatsOverviewGrid(summary: summary)
+                    .padding(.top, 28)
+
+                StatsEmptyCard(
+                    eyebrow: "Patterns",
+                    title: "More patterns appear as you log.",
+                    detail: "What's working, by-bag breakdowns, and dial-in trends start showing once you have a handful of brews on each bag."
+                )
+                .padding(.top, 24)
+
+                if !summary.loggedSoFar.isEmpty {
+                    statsSectionHeader("Logged so far")
+                        .padding(.top, 28)
+                    VStack(spacing: 0) {
+                        ForEach(summary.loggedSoFar) { row in
+                            StatsBrewRow(row: row)
+                        }
+                    }
+                }
+
+                Spacer().frame(height: 100)
+            }
+            .padding(.horizontal, 24)
+            .padding(.top, 12)
+        }
+        .scrollIndicators(.hidden)
+    }
+
+    private var populatedState: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                statsHeader
+                StatsOverviewGrid(summary: summary)
+                    .padding(.top, 28)
+
+                BrewActivityStrip(days: summary.dailyCounts, total: summary.totalBrews)
+                    .padding(.top, 30)
+
+                if hasWorkingContent {
+                    statsSectionHeader("What's working")
+                        .padding(.top, 30)
+                    VStack(spacing: 0) {
+                        ForEach(summary.workingBrews) { row in
+                            StatsBrewRow(row: row)
+                        }
+                        if let bestBag = summary.bestBag {
+                            StatsBagRow(summary: bestBag, label: "Best bag")
+                        }
+                        if let bestRecipeName = summary.bestRecipeName {
+                            StatsInfoRow(title: "Best recipe", detail: bestRecipeName, value: "Saved")
+                        }
+                    }
+                }
+
+                if !summary.bagSummaries.isEmpty {
+                    statsSectionHeader("By bag")
+                        .padding(.top, 30)
+                    VStack(spacing: 0) {
+                        ForEach(summary.bagSummaries) { bag in
+                            StatsBagRow(summary: bag)
+                        }
+                    }
+                }
+
+                if !summary.dialInRows.isEmpty {
+                    statsSectionHeader(dialInTitle)
+                        .padding(.top, 30)
+                    VStack(spacing: 0) {
+                        ForEach(summary.dialInRows) { row in
+                            StatsDialInRow(row: row)
+                        }
+                    }
+                }
+
+                Spacer().frame(height: 100)
+            }
+            .padding(.horizontal, 24)
+            .padding(.top, 12)
+        }
+        .scrollIndicators(.hidden)
+    }
+
+    private var statsHeader: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Eyebrow(statsEyebrow)
+                Spacer()
+                Text("Pro")
+                    .font(Theme.body(10, weight: .semibold))
+                    .tracking(1.1)
+                    .textCase(.uppercase)
+                    .foregroundStyle(Theme.ink3)
+                    .padding(.horizontal, 9)
+                    .padding(.vertical, 4)
+                    .background(Theme.card, in: .capsule)
+                    .overlay(Capsule().stroke(Theme.rule, lineWidth: 0.5))
+            }
+
+            Text("Stats")
+                .font(.system(size: 42, weight: .medium, design: .serif))
+                .tracking(-1.2)
+                .foregroundStyle(Theme.ink)
+
+            if !summary.isSparse {
+                Text("A quiet ledger of what you've brewed and what's been working.")
+                    .font(Theme.body(14))
+                    .foregroundStyle(Theme.ink2)
+                    .lineSpacing(3)
+                    .frame(maxWidth: 320, alignment: .leading)
+                    .padding(.top, 4)
+            }
+        }
+    }
+
+    private var statsEyebrow: String {
+        if summary.totalBrews <= 0 {
+            return "Stats"
+        }
+        let start = summary.windowStart.formatted(.dateTime.month(.abbreviated).day())
+        let dayCount = Calendar.current.dateComponents([.day], from: summary.windowStart, to: summary.windowEnd).day ?? 29
+        return "\(dayCount + 1) days / since \(start)"
+    }
+
+    private var hasWorkingContent: Bool {
+        !summary.workingBrews.isEmpty || summary.bestBag != nil || summary.bestRecipeName != nil
+    }
+
+    private var dialInTitle: String {
+        if let title = summary.dialInBagTitle {
+            return "Dial-in / \(title)"
+        }
+        return "Dial-in"
+    }
+
+    private func statsSectionHeader(_ title: String) -> some View {
+        Eyebrow(title, color: Theme.accent)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct StatsOverviewGrid: View {
+    let summary: StatsSummary
+
+    private let columns = [
+        GridItem(.flexible(), spacing: 24),
+        GridItem(.flexible(), spacing: 24)
+    ]
+
+    var body: some View {
+        LazyVGrid(columns: columns, alignment: .leading, spacing: 22) {
+            StatsMetric(value: "\(summary.totalBrews)", label: "Total brews", caption: summary.totalBrews == 1 ? "this month" : "this month")
+            StatsMetric(value: "\(summary.activeBagCount)", label: "Active bags")
+            StatsMetric(
+                value: summary.favoriteMethod?.displayName ?? "-",
+                label: "Favorite method",
+                caption: summary.favoriteMethod == nil ? "more data needed" : nil
+            )
+            StatsMetric(
+                value: averageRatingLabel,
+                label: "Avg rating",
+                caption: summary.averageRating == nil ? "rate a brew to see this" : "out of 5"
+            )
+        }
+    }
+
+    private var averageRatingLabel: String {
+        guard let average = summary.averageRating else { return "-" }
+        return average.formatted(.number.precision(.fractionLength(average.truncatingRemainder(dividingBy: 1) == 0 ? 0 : 1)))
+    }
+}
+
+private struct StatsMetric: View {
+    let value: String
+    let label: String
+    var caption: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(value)
+                .font(.system(size: value.count > 9 ? 22 : 30, weight: .medium, design: .serif))
+                .tracking(-0.6)
+                .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+                .foregroundStyle(Theme.ink)
+            Eyebrow(label)
+            if let caption {
+                Text(caption)
+                    .font(Theme.body(11))
+                    .foregroundStyle(Theme.ink2)
+                    .lineLimit(2)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct BrewActivityStrip: View {
+    let days: [StatsSummary.DailyCount]
+    let total: Int
+
+    private var maxCount: Int {
+        max(days.map(\.count).max() ?? 0, 1)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text("Brews / last 30 days")
+                    .font(Theme.body(12, weight: .medium))
+                    .foregroundStyle(Theme.ink2)
+                Spacer()
+                Text("\(total) total")
+                    .font(Theme.body(12))
+                    .foregroundStyle(Theme.ink3)
+            }
+
+            HStack(alignment: .bottom, spacing: 4) {
+                ForEach(days) { day in
+                    RoundedRectangle(cornerRadius: 1.5)
+                        .fill(day.count > 0 ? Theme.ink.opacity(0.82) : Theme.rule)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: height(for: day.count))
+                        .accessibilityLabel("\(day.count) brews")
+                }
+                RoundedRectangle(cornerRadius: 1.5)
+                    .fill(Theme.accent)
+                    .frame(width: 6, height: 12)
+                    .accessibilityHidden(true)
+            }
+            .frame(height: 44, alignment: .bottom)
+
+            HStack {
+                Text(days.first?.date.formatted(.dateTime.month(.abbreviated).day()).uppercased() ?? "")
+                Spacer()
+                Text("Today")
+            }
+            .font(Theme.body(10, weight: .semibold))
+            .tracking(1.1)
+            .textCase(.uppercase)
+            .foregroundStyle(Theme.ink3)
+        }
+    }
+
+    private func height(for count: Int) -> CGFloat {
+        guard count > 0 else { return 2 }
+        let scaled = CGFloat(count) / CGFloat(maxCount) * 42
+        return min(max(scaled, 4), 42)
+    }
+}
+
+private struct StatsBrewRow: View {
+    let row: StatsSummary.BrewRow
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HairRule()
+            HStack(alignment: .center) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(row.title)
+                        .font(.system(size: 20, weight: .medium, design: .serif))
+                        .tracking(-0.4)
+                        .foregroundStyle(Theme.ink)
+                    Text(row.detail)
+                        .font(Theme.body(12))
+                        .foregroundStyle(Theme.ink2)
+                        .lineLimit(1)
+                }
+                Spacer()
+                VStack(alignment: .trailing, spacing: 6) {
+                    Text(row.ratioLabel)
+                        .font(.system(size: 16, weight: .medium, design: .serif))
+                        .monospacedDigit()
+                        .foregroundStyle(Theme.accent)
+                    if let rating = row.rating, rating > 0 {
+                        RatingDots(value: rating, size: 5)
+                    }
+                }
+            }
+            .padding(.vertical, 15)
+        }
+    }
+}
+
+private struct StatsBagRow: View {
+    let summary: StatsSummary.BagSummary
+    var label: String?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HairRule()
+            HStack(alignment: .center) {
+                VStack(alignment: .leading, spacing: 4) {
+                    if let label {
+                        Eyebrow(label)
+                    }
+                    Text(summary.title)
+                        .font(.system(size: 20, weight: .medium, design: .serif))
+                        .tracking(-0.4)
+                        .foregroundStyle(Theme.ink)
+                    Text("\(summary.brewCount) brews / \(summary.methodLabel)")
+                        .font(Theme.body(12))
+                        .foregroundStyle(Theme.ink2)
+                        .lineLimit(1)
+                }
+                Spacer()
+                VStack(alignment: .trailing, spacing: 5) {
+                    Text(summary.ratioLabel)
+                        .font(.system(size: 16, weight: .medium, design: .serif))
+                        .foregroundStyle(Theme.accent)
+                    Text(ratingLabel)
+                        .font(Theme.body(11, weight: .medium))
+                        .foregroundStyle(Theme.ink3)
+                }
+            }
+            .padding(.vertical, 15)
+        }
+    }
+
+    private var ratingLabel: String {
+        guard let average = summary.averageRating else { return "No ratings" }
+        return "\(average.formatted(.number.precision(.fractionLength(average.truncatingRemainder(dividingBy: 1) == 0 ? 0 : 1)))) avg"
+    }
+}
+
+private struct StatsDialInRow: View {
+    let row: StatsSummary.DialInRow
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HairRule()
+            HStack(alignment: .center) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(row.createdAt.formatted(.dateTime.month(.abbreviated).day()))
+                        .font(.system(size: 18, weight: .medium, design: .serif))
+                        .foregroundStyle(Theme.ink)
+                    Text(row.detail)
+                        .font(Theme.body(12))
+                        .foregroundStyle(Theme.ink2)
+                        .lineLimit(1)
+                }
+                Spacer()
+                if let rating = row.rating, rating > 0 {
+                    RatingDots(value: rating, size: 5)
+                }
+            }
+            .padding(.vertical, 14)
+        }
+    }
+}
+
+private struct StatsInfoRow: View {
+    let title: String
+    let detail: String
+    let value: String
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HairRule()
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(.system(size: 20, weight: .medium, design: .serif))
+                        .foregroundStyle(Theme.ink)
+                    Text(detail)
+                        .font(Theme.body(12))
+                        .foregroundStyle(Theme.ink2)
+                        .lineLimit(1)
+                }
+                Spacer()
+                Text(value)
+                    .font(Theme.body(12, weight: .semibold))
+                    .foregroundStyle(Theme.accent)
+            }
+            .padding(.vertical, 15)
+        }
+    }
+}
+
+private struct StatsProFeatureRow: View {
+    let number: String
+    let title: String
+    let detail: String
+    var showsRule = true
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(alignment: .top, spacing: 22) {
+                Text(number)
+                    .font(Theme.body(11, weight: .bold))
+                    .foregroundStyle(Theme.accent)
+                    .frame(width: 20, alignment: .leading)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(.system(size: 18, weight: .medium, design: .serif))
+                        .tracking(-0.2)
+                        .foregroundStyle(Theme.ink)
+                    Text(detail)
+                        .font(Theme.body(13))
+                        .foregroundStyle(Theme.ink2)
+                        .lineSpacing(2)
+                }
+            }
+            .padding(.vertical, 16)
+            if showsRule {
+                HairRule()
+                    .padding(.leading, 42)
+            }
+        }
+    }
+}
+
+private struct StatsEmptyCard: View {
+    let eyebrow: String
+    let title: String
+    let detail: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Eyebrow(eyebrow)
+            Text(title)
+                .font(.system(size: 22, weight: .medium, design: .serif))
+                .tracking(-0.4)
+                .foregroundStyle(Theme.ink)
+            Text(detail)
+                .font(Theme.body(14))
+                .foregroundStyle(Theme.ink2)
+                .lineSpacing(3)
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Theme.card, in: RoundedRectangle(cornerRadius: Theme.cardRadius, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: Theme.cardRadius, style: .continuous)
+                .stroke(Theme.rule, lineWidth: 0.5)
+        )
+    }
+}

--- a/BeanBookTests/StatsSummaryTests.swift
+++ b/BeanBookTests/StatsSummaryTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import BeanBook
+
+@Suite("Stats summary")
+@MainActor
+struct StatsSummaryTests {
+    private let calendar = Calendar(identifier: .gregorian)
+    private let now = Date(timeIntervalSinceReferenceDate: 800_000)
+
+    @Test("empty inputs produce empty summary")
+    func emptyInputs() {
+        let summary = StatsSummary.build(brews: [], bags: [], presets: [], now: now, calendar: calendar)
+
+        #expect(summary.totalBrews == 0)
+        #expect(summary.activeBagCount == 0)
+        #expect(summary.favoriteMethod == nil)
+        #expect(summary.averageRating == nil)
+        #expect(summary.dailyCounts.count == 30)
+        #expect(summary.isSparse)
+        #expect(summary.bagSummaries.isEmpty)
+        #expect(summary.dialInRows.isEmpty)
+    }
+
+    @Test("sparse summary keeps available values without claiming favorite method")
+    func sparseInputs() {
+        let bag = Bag(brand: "Onyx", name: "Geometry")
+        let brew = Brew(method: .espresso, doseGrams: 18, yieldGrams: 36, brewTimeSeconds: 30, rating: 5, bag: bag, createdAt: now)
+        bag.brews = [brew]
+
+        let summary = StatsSummary.build(brews: [brew], bags: [bag], presets: [], now: now, calendar: calendar)
+
+        #expect(summary.totalBrews == 1)
+        #expect(summary.activeBagCount == 1)
+        #expect(summary.favoriteMethod == nil)
+        #expect(summary.averageRating == 5)
+        #expect(summary.isSparse)
+        #expect(summary.loggedSoFar.count == 1)
+    }
+
+    @Test("populated summary derives overview, bag summaries, and daily counts")
+    func populatedInputs() {
+        let bag = Bag(brand: "Onyx", name: "Geometry")
+        let brews = (0..<5).map { index in
+            Brew(
+                method: .espresso,
+                doseGrams: 18,
+                yieldGrams: 36 + Double(index),
+                brewTimeSeconds: 28 + index,
+                rating: index == 0 ? 3 : 4,
+                bag: bag,
+                createdAt: calendar.date(byAdding: .day, value: -index, to: now)!
+            )
+        }
+        bag.brews = brews
+
+        let summary = StatsSummary.build(brews: brews, bags: [bag], presets: [], now: now, calendar: calendar)
+
+        #expect(summary.totalBrews == 5)
+        #expect(summary.activeBagCount == 1)
+        #expect(summary.favoriteMethod == .espresso)
+        #expect(summary.averageRating == 3.8)
+        #expect(!summary.isSparse)
+        #expect(summary.dailyCounts.reduce(0) { $0 + $1.count } == 5)
+        #expect(summary.bagSummaries.first?.brewCount == 5)
+        #expect(summary.dialInRows.count == 5)
+    }
+
+    @Test("unrated brews keep rating nil")
+    func unratedInputs() {
+        let brew = Brew(method: .pourOver, doseGrams: 20, yieldGrams: 320, brewTimeSeconds: 180, createdAt: now)
+        let summary = StatsSummary.build(brews: [brew], bags: [], presets: [], now: now, calendar: calendar)
+
+        #expect(summary.averageRating == nil)
+    }
+
+    @Test("pinned bag drives dial-in rows when present")
+    func pinnedBagDrivesDialInRows() {
+        let pinned = Bag(brand: "Sey", name: "A", isPinned: true)
+        let recent = Bag(brand: "Onyx", name: "B")
+        let pinnedBrew = Brew(method: .espresso, doseGrams: 18, yieldGrams: 36, brewTimeSeconds: 30, rating: 4, bag: pinned, createdAt: calendar.date(byAdding: .day, value: -2, to: now)!)
+        let recentBrew = Brew(method: .espresso, doseGrams: 19, yieldGrams: 38, brewTimeSeconds: 31, rating: 5, bag: recent, createdAt: now)
+        pinned.brews = [pinnedBrew]
+        recent.brews = [recentBrew]
+
+        let summary = StatsSummary.build(brews: [recentBrew, pinnedBrew], bags: [pinned, recent], presets: [], now: now, calendar: calendar)
+
+        #expect(summary.dialInBagTitle == pinned.displayTitle)
+        #expect(summary.dialInRows.map(\.brewID) == [pinnedBrew.persistentModelID])
+    }
+}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ iOS app for tracking coffee bags and shots — built for the home espresso enthu
 - **Track your beans.** Origin, roast date, tasting notes, process. Linked to every shot.
 - **Brew it again.** Tap a recent shot to log it again with the same dose, yield, time, and grind.
 - **Dial in a new bag.** All four shot variables on one screen with "was 18 g" hints under any field that diverged from your last brew.
+- **See what is working.** BeanBook Pro adds local stats for overview, by-bag patterns, and dial-in history.
 
 ## Pro
 
@@ -95,7 +96,7 @@ Enable Pages: GitHub repo → Settings → Pages → **Source: Deploy from a bra
 BeanBook/                 iOS target
 ├── App/                  RootTabView, app entry
 ├── Core/                 Models, Stores, Services
-├── Features/             Brews, Bags, Shop, Onboarding, Recipes, Settings
+├── Features/             Brews, Bags, Stats, Shop, Onboarding, Recipes, Settings
 ├── Pro/                  ProEntitlement, PaywallSheet
 └── Shared/               Theme, palettes, primitives, extensions
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # BeanBook — Architecture
 
-What lives where, and why. Reflects the app's current state (3-step brew log, prefill snapshot, bag pinning, recent-shots strip).
+What lives where, and why. Reflects the app's current state (3-step brew log, prefill snapshot, bag pinning, recent-shots strip, Pro stats).
 
 ## Targets
 
@@ -60,7 +60,7 @@ Pro quotas are enforced at the store level — `create(...)` throws `QuotaExceed
 
 ### Root navigation (`App/RootTabView.swift`)
 
-Three-tab `TabView` using iOS 18's `Tab` initializer: **Brews**, **Bags**, **Shop**. Each tab wraps in its own `NavigationStack` with `.navigationDestination(for:)` for `Brew` and `Bag`. The center "+" tab triggers `NewBrewSheet` rather than navigating.
+Top-level `TabView` using iOS 18's `Tab` initializer: **Today**, **Beans**, **Stats**, and **Shop**. Each content tab wraps in its own `NavigationStack`. The center "+" tab triggers `NewBrewSheet` rather than navigating.
 
 ## Feature layer
 
@@ -72,7 +72,7 @@ The dominant feature. Recent rework collapsed a 5-step wizard into 3 steps with 
 
 | File | Role |
 |---|---|
-| `BrewListView.swift` | The Brews tab. Renders the `RecentShotsStrip` above the list and a `.contextMenu` "Brew again" on each row. Hot-start uses `.sheet(item: $hotStartBrew)`. |
+| `BrewListView.swift` | The all-brews destination. Renders the `RecentShotsStrip`, a `Saved recipes` entry when presets exist, and a `.contextMenu` "Brew again" on each row. Hot-start uses `.sheet(item: $hotStartBrew)`. |
 | `BrewDetailView.swift` | Single-brew detail; "Brew this again" enters `NewBrewSheet(prefill:)`. |
 | `NewBrewSheet.swift` | The 3-step flow: **Context** (method + bag) → **Shot** (dose, yield, time, grind, all visible) → **Outcome** (rating, notes, save-as-recipe). |
 | `Components/MethodPicker.swift` | Method chip row used in step 0. |
@@ -99,11 +99,20 @@ The dominant feature. Recent rework collapsed a 5-step wizard into 3 steps with 
 |---|---|
 | `ShopView.swift` | Browses `CatalogService.beans`. Featured card at top (forest-on-sage editorial card with a layered tilted swatch), "Near you" section if location is granted, then filtered list. `.accentPill` "Add to beans" imports a catalog entry into SwiftData via `BagStore`. |
 
+### Stats (`Features/Stats/`)
+
+Stats are a BeanBook Pro feature, but the tab is visible to everyone. Non-Pro users see a locked state that leads with one-time-purchase positioning and routes to `PaywallSheet`.
+
+| File | Role |
+|---|---|
+| `StatsView.swift` | The Stats tab. Renders locked, empty, sparse, and populated states from local SwiftData data. Presents `NewBrewSheet` from the empty state and `PaywallSheet` from the locked state. |
+| `StatsSummary.swift` | Pure aggregation builder over `[Brew]`, `[Bag]`, and `[BrewPreset]`. Derives 30-day totals, active bags, favorite method, average rating, daily brew counts, working brews, by-bag summaries, and dial-in rows. |
+
 ### Recipes (`Features/Recipes/`)
 
 | File | Role |
 |---|---|
-| `RecipesView.swift` | Lists `BrewPreset`s. Tapping a preset constructs a temp `Brew` and presents `NewBrewSheet(prefill:)`. Inherits the hot-start "skip to Step 2" behavior for free. |
+| `RecipesView.swift` | Lists `BrewPreset`s. Tapping a preset constructs a temp `Brew` and presents `NewBrewSheet(prefill:)`. Recipes are no longer a top-level tab; they are surfaced from Brews because they primarily support repeating what worked. |
 
 ### Onboarding (`Features/Onboarding/`)
 
@@ -128,6 +137,8 @@ The Pro row leads with **"One-time purchase · Unlimited everything · Future fe
 | `PaywallSheet.swift` | The full paywall. One-time-purchase positioning is non-negotiable (hero "One purchase. / Yours forever.", value-prop chip strip, CTA reads "Unlock Pro · $X once"). |
 
 `ProQuota` defines the free-tier ceilings (`bags`, `brews`, `recipes`). Stores enforce. Views surface `PaywallSheet` on `QuotaExceededError`.
+
+Stats are Pro-only but read from existing local data. They do not change the free core logging flow and do not introduce sync or backend dependencies.
 
 ## Theme (`Shared/Theme/`)
 

--- a/docs/superpowers/plans/active/2026-05-06-stats-tab.md
+++ b/docs/superpowers/plans/active/2026-05-06-stats-tab.md
@@ -1,0 +1,678 @@
+# Stats Tab Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the top-level Recipes tab with a Pro-gated Stats tab, and resurface saved recipes from Brews.
+
+**Architecture:** Stats remain local and derived from existing SwiftData `Brew`, `Bag`, and `BrewPreset` models. Add a pure `StatsSummary` builder for testable aggregation, then keep `StatsView` focused on rendering the four states from the approved mock: locked, empty, sparse, populated. Use existing theme primitives and paywall flow; do not add Firebase, Chart framework dependency, or new persisted models.
+
+**Tech Stack:** Swift 6, SwiftUI, SwiftData, Swift Testing, StoreKit-backed existing `ProEntitlement`, file-system synchronized Xcode groups.
+
+---
+
+## File Structure
+
+- Create: `BeanBook/Features/Stats/StatsSummary.swift`
+  - Pure local aggregation types and `StatsSummary.build(...)`.
+  - No SwiftUI. No SwiftData queries. Accept plain `[Brew]`, `[Bag]`, `[BrewPreset]`, `now`, and `calendar`.
+- Create: `BeanBook/Features/Stats/StatsView.swift`
+  - SwiftUI screen with `@Query` for brews, bags, and presets.
+  - Renders locked, no-brews, sparse, and populated states.
+  - Owns `showPaywall` and `showAddBrew`.
+- Modify: `BeanBook/App/RootTabView.swift`
+  - Replace `.recipes` tab selection with `.stats`.
+  - Add `StatsView()` as the third content tab.
+- Modify: `BeanBook/Features/Brews/BrewListView.swift`
+  - Add `@Query` for `BrewPreset`.
+  - Add a `Saved recipes` row/entry near `RecentShotsStrip`.
+  - Present existing `RecipesView` from Brews.
+- Create: `BeanBookTests/StatsSummaryTests.swift`
+  - Swift Testing coverage for empty, sparse, populated, unrated, mixed bag, and pinned-bag dial-in behavior.
+- Modify: `docs/architecture.md`
+  - Update Root navigation and Stats/Recipes feature descriptions.
+- Modify: `README.md`
+  - Update the top-level feature list if needed so Recipes is no longer described as a tab-level destination.
+
+Because the project uses `PBXFileSystemSynchronizedRootGroup`, new Swift files under `BeanBook/` and `BeanBookTests/` should be picked up without editing `BeanBook.xcodeproj/project.pbxproj`.
+
+---
+
+### Task 1: Stats Summary Builder
+
+**Files:**
+- Create: `BeanBook/Features/Stats/StatsSummary.swift`
+- Test: `BeanBookTests/StatsSummaryTests.swift`
+
+- [ ] **Step 1: Write failing tests for summary derivation**
+
+Create `BeanBookTests/StatsSummaryTests.swift`:
+
+```swift
+import Foundation
+import SwiftData
+import Testing
+@testable import BeanBook
+
+@Suite("Stats summary")
+struct StatsSummaryTests {
+    private let calendar = Calendar(identifier: .gregorian)
+    private let now = Date(timeIntervalSinceReferenceDate: 800_000)
+
+    @Test("empty inputs produce empty summary")
+    func emptyInputs() {
+        let summary = StatsSummary.build(brews: [], bags: [], presets: [], now: now, calendar: calendar)
+
+        #expect(summary.totalBrews == 0)
+        #expect(summary.activeBagCount == 0)
+        #expect(summary.favoriteMethod == nil)
+        #expect(summary.averageRating == nil)
+        #expect(summary.dailyCounts.count == 30)
+        #expect(summary.isSparse)
+        #expect(summary.bagSummaries.isEmpty)
+        #expect(summary.dialInRows.isEmpty)
+    }
+
+    @Test("sparse summary keeps available values without claiming favorite method")
+    func sparseInputs() {
+        let bag = Bag(brand: "Onyx", name: "Geometry")
+        let brew = Brew(method: .espresso, doseGrams: 18, yieldGrams: 36, brewTimeSeconds: 30, rating: 5, bag: bag, createdAt: now)
+        bag.brews = [brew]
+
+        let summary = StatsSummary.build(brews: [brew], bags: [bag], presets: [], now: now, calendar: calendar)
+
+        #expect(summary.totalBrews == 1)
+        #expect(summary.activeBagCount == 1)
+        #expect(summary.favoriteMethod == nil)
+        #expect(summary.averageRating == 5)
+        #expect(summary.isSparse)
+        #expect(summary.loggedSoFar.count == 1)
+    }
+
+    @Test("populated summary derives overview, bag summaries, and daily counts")
+    func populatedInputs() {
+        let bag = Bag(brand: "Onyx", name: "Geometry")
+        let brews = (0..<5).map { index in
+            Brew(
+                method: .espresso,
+                doseGrams: 18,
+                yieldGrams: 36 + Double(index),
+                brewTimeSeconds: 28 + index,
+                rating: index == 0 ? 3 : 4,
+                bag: bag,
+                createdAt: calendar.date(byAdding: .day, value: -index, to: now)!
+            )
+        }
+        bag.brews = brews
+
+        let summary = StatsSummary.build(brews: brews, bags: [bag], presets: [], now: now, calendar: calendar)
+
+        #expect(summary.totalBrews == 5)
+        #expect(summary.activeBagCount == 1)
+        #expect(summary.favoriteMethod == .espresso)
+        #expect(summary.averageRating == 3.8)
+        #expect(!summary.isSparse)
+        #expect(summary.dailyCounts.reduce(0) { $0 + $1.count } == 5)
+        #expect(summary.bagSummaries.first?.brewCount == 5)
+        #expect(summary.dialInRows.count == 5)
+    }
+
+    @Test("unrated brews keep rating nil")
+    func unratedInputs() {
+        let brew = Brew(method: .pourOver, doseGrams: 20, yieldGrams: 320, brewTimeSeconds: 180, createdAt: now)
+        let summary = StatsSummary.build(brews: [brew], bags: [], presets: [], now: now, calendar: calendar)
+
+        #expect(summary.averageRating == nil)
+    }
+
+    @Test("pinned bag drives dial-in rows when present")
+    func pinnedBagDrivesDialInRows() {
+        let pinned = Bag(brand: "Sey", name: "A", isPinned: true)
+        let recent = Bag(brand: "Onyx", name: "B")
+        let pinnedBrew = Brew(method: .espresso, doseGrams: 18, yieldGrams: 36, brewTimeSeconds: 30, rating: 4, bag: pinned, createdAt: calendar.date(byAdding: .day, value: -2, to: now)!)
+        let recentBrew = Brew(method: .espresso, doseGrams: 19, yieldGrams: 38, brewTimeSeconds: 31, rating: 5, bag: recent, createdAt: now)
+        pinned.brews = [pinnedBrew]
+        recent.brews = [recentBrew]
+
+        let summary = StatsSummary.build(brews: [recentBrew, pinnedBrew], bags: [pinned, recent], presets: [], now: now, calendar: calendar)
+
+        #expect(summary.dialInBagTitle == pinned.displayTitle)
+        #expect(summary.dialInRows.map(\.brewID) == [pinnedBrew.persistentModelID])
+    }
+}
+```
+
+- [ ] **Step 2: Run tests and confirm they fail**
+
+Run:
+
+```bash
+xcodebuild test -project BeanBook.xcodeproj -scheme BeanBook -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' -only-testing:BeanBookTests/StatsSummaryTests
+```
+
+Expected: fails because `StatsSummary` does not exist.
+
+- [ ] **Step 3: Implement the pure summary builder**
+
+Create `BeanBook/Features/Stats/StatsSummary.swift`:
+
+```swift
+import Foundation
+import SwiftData
+
+struct StatsSummary {
+    struct DailyCount: Identifiable, Equatable {
+        let id: Date
+        let date: Date
+        let count: Int
+    }
+
+    struct BagSummary: Identifiable, Equatable {
+        let id: PersistentIdentifier
+        let title: String
+        let brewCount: Int
+        let averageRating: Double?
+        let lastBrewedAt: Date
+        let methodLabel: String
+        let ratioLabel: String
+    }
+
+    struct BrewRow: Identifiable, Equatable {
+        let id: PersistentIdentifier
+        let brewID: PersistentIdentifier
+        let title: String
+        let detail: String
+        let ratioLabel: String
+        let rating: Int?
+        let createdAt: Date
+    }
+
+    struct DialInRow: Identifiable, Equatable {
+        let id: PersistentIdentifier
+        let brewID: PersistentIdentifier
+        let detail: String
+        let rating: Int?
+        let createdAt: Date
+    }
+
+    let windowStart: Date
+    let windowEnd: Date
+    let totalBrews: Int
+    let totalLifetimeBrews: Int
+    let activeBagCount: Int
+    let favoriteMethod: BrewMethod?
+    let averageRating: Double?
+    let dailyCounts: [DailyCount]
+    let workingBrews: [BrewRow]
+    let bestBag: BagSummary?
+    let bestRecipeName: String?
+    let bagSummaries: [BagSummary]
+    let dialInBagTitle: String?
+    let dialInRows: [DialInRow]
+    let loggedSoFar: [BrewRow]
+
+    var isSparse: Bool { totalBrews < 3 }
+}
+
+extension StatsSummary {
+    static func build(
+        brews: [Brew],
+        bags: [Bag],
+        presets: [BrewPreset],
+        now: Date = .now,
+        calendar: Calendar = .current
+    ) -> StatsSummary {
+        let end = now
+        let start = calendar.date(byAdding: .day, value: -29, to: calendar.startOfDay(for: now)) ?? now
+        let sorted = brews.sorted { $0.createdAt > $1.createdAt }
+        let windowBrews = sorted.filter { $0.createdAt >= start && $0.createdAt <= end }
+        let rated = windowBrews.compactMap(\.rating).filter { $0 > 0 }
+        let activeBags = Set(windowBrews.compactMap { $0.bag?.persistentModelID })
+
+        return StatsSummary(
+            windowStart: start,
+            windowEnd: end,
+            totalBrews: windowBrews.count,
+            totalLifetimeBrews: brews.count,
+            activeBagCount: activeBags.count,
+            favoriteMethod: favoriteMethod(in: windowBrews),
+            averageRating: average(rated.map(Double.init)),
+            dailyCounts: dailyCounts(from: windowBrews, start: start, now: now, calendar: calendar),
+            workingBrews: workingBrews(from: windowBrews),
+            bestBag: bestBag(from: windowBrews),
+            bestRecipeName: bestRecipeName(from: presets),
+            bagSummaries: bagSummaries(from: windowBrews),
+            dialInBagTitle: dialInBag(from: sorted, bags: bags)?.displayTitle,
+            dialInRows: dialInRows(from: sorted, bags: bags),
+            loggedSoFar: Array(sorted.prefix(5)).map(BrewRow.init)
+        )
+    }
+}
+```
+
+Complete helper functions in the same file:
+
+- `favoriteMethod(in:)` returns nil until there are at least 3 window brews.
+- `dailyCounts(from:start:now:calendar:)` returns exactly 30 days.
+- `workingBrews(from:)` returns the top 3 rated brews, sorted rating desc then date desc.
+- `bagSummaries(from:)` groups by `bag.persistentModelID`, excludes nil bags, sorts by last brewed desc.
+- `bestBag(from:)` requires at least 3 brews on a bag and at least one rating.
+- `bestRecipeName(from:)` returns the newest non-empty preset name, or nil.
+- `dialInBag(from:bags:)` chooses pinned bag first, otherwise the most recent brew's bag.
+- `dialInRows(from:bags:)` returns up to 5 espresso brews for the dial-in bag.
+- `average(_:)` rounds to one decimal place.
+- `BrewRow.init(_:)` and `DialInRow.init(_:)` should use existing `formattedRatio` and `formattedTime`.
+
+Keep helper functions `private` except initializers used by tests.
+
+- [ ] **Step 4: Run tests and confirm they pass**
+
+Run:
+
+```bash
+xcodebuild test -project BeanBook.xcodeproj -scheme BeanBook -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' -only-testing:BeanBookTests/StatsSummaryTests
+```
+
+Expected: `StatsSummaryTests` passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add BeanBook/Features/Stats/StatsSummary.swift BeanBookTests/StatsSummaryTests.swift
+git commit -m "feat: add stats summary builder"
+```
+
+---
+
+### Task 2: Stats View States
+
+**Files:**
+- Create: `BeanBook/Features/Stats/StatsView.swift`
+
+- [ ] **Step 1: Create the Stats view shell**
+
+Create `BeanBook/Features/Stats/StatsView.swift` with:
+
+```swift
+import SwiftUI
+import SwiftData
+
+struct StatsView: View {
+    @Environment(ProEntitlement.self) private var pro
+    @Query(sort: \Brew.createdAt, order: .reverse) private var brews: [Brew]
+    @Query(sort: \Bag.createdAt, order: .reverse) private var bags: [Bag]
+    @Query(sort: \BrewPreset.createdAt, order: .reverse) private var presets: [BrewPreset]
+
+    @State private var showPaywall = false
+    @State private var showAddBrew = false
+
+    private var summary: StatsSummary {
+        StatsSummary.build(brews: brews, bags: bags, presets: presets)
+    }
+
+    var body: some View {
+        ZStack {
+            Theme.background.ignoresSafeArea()
+
+            if !pro.isPro {
+                lockedState
+            } else if brews.isEmpty {
+                noBrewsState
+            } else if summary.isSparse {
+                sparseState
+            } else {
+                populatedState
+            }
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(.hidden, for: .navigationBar)
+        .sheet(isPresented: $showPaywall) {
+            PaywallSheet(headline: "Stats are included with BeanBook Pro.")
+        }
+        .sheet(isPresented: $showAddBrew) {
+            NewBrewSheet()
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Add locked state**
+
+Implement a private `lockedState` matching the approved mock:
+
+- Eyebrow `BeanBook Pro`.
+- Title `Stats`.
+- Body: `Stats are included with BeanBook Pro - a one-time purchase that also unlocks unlimited bags and exports.`
+- Four rows:
+  - `01` / `Overview` / `Total brews, active bags, favorite method, average rating.`
+  - `02` / `What's working` / `Highest-rated brews, your best bag, best saved recipe.`
+  - `03` / `By bag` / `Brew count, average rating, common ratio, last brewed.`
+  - `04` / `Dial-in` / `Espresso shot history with grind and rating changes.`
+- Bottom CTA button `Unlock Pro` or `Unlock Pro once` that sets `showPaywall = true`.
+
+Use `HairRule`, `Eyebrow`, `Theme.body`, and serif title styles from existing screens.
+
+- [ ] **Step 3: Add no-brews state**
+
+Implement a private `noBrewsState`:
+
+- Eyebrow `Stats`.
+- Large serif title split by color: `Nothing\nto show\nyet.`
+- Body: `Log your first brew and patterns will start to appear here - what's working, by bag, dial-in.`
+- Accent pill CTA `Log a brew` with right arrow that sets `showAddBrew = true`.
+- Match the spacing and bottom safe-area clearance used by `TodayEmptyView`.
+
+- [ ] **Step 4: Add sparse state**
+
+Implement a private `sparseState`:
+
+- Header with `statsEyebrow`.
+- Overview grid with available values.
+- Favorite method shown as `-` and caption `more data needed` when `summary.favoriteMethod == nil`.
+- Average rating shown as `-` and caption `rate a brew to see this` when nil.
+- Card with eyebrow `Patterns`, title `More patterns appear as you log.`, and body copy from the spec.
+- `Logged so far` section from `summary.loggedSoFar`.
+
+- [ ] **Step 5: Add populated state**
+
+Implement a private `populatedState`:
+
+- Same header as sparse.
+- Overview grid.
+- `BrewActivityStrip(days: summary.dailyCounts)`.
+- `What's working` section using `summary.workingBrews`, `summary.bestBag`, and `summary.bestRecipeName`, omitting empty rows.
+- `By bag` section using `summary.bagSummaries`.
+- `Dial-in` section using `summary.dialInRows`, with the selected bag title when available.
+
+- [ ] **Step 6: Add small local components**
+
+Keep these private in `StatsView.swift`:
+
+- `StatsOverviewGrid`
+- `StatsMetric`
+- `BrewActivityStrip`
+- `StatsBrewRow`
+- `StatsBagRow`
+- `StatsProFeatureRow`
+- `StatsEmptyCard`
+
+Do not introduce a charting dependency. `BrewActivityStrip` should use a fixed-height `HStack` of rounded rectangles, compute `maxCount`, and clamp each bar between 4 and 42 points tall.
+
+- [ ] **Step 7: Build**
+
+Run:
+
+```bash
+xcodebuild -project BeanBook.xcodeproj -scheme BeanBook -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add BeanBook/Features/Stats/StatsView.swift
+git commit -m "feat: add stats tab view states"
+```
+
+---
+
+### Task 3: Replace Recipes Tab With Stats
+
+**Files:**
+- Modify: `BeanBook/App/RootTabView.swift`
+
+- [ ] **Step 1: Update tab selection enum**
+
+Change:
+
+```swift
+enum TabSelection: Hashable {
+    case today, beans, recipes, add
+}
+```
+
+To:
+
+```swift
+enum TabSelection: Hashable {
+    case today, beans, stats, shop, add
+}
+```
+
+- [ ] **Step 2: Replace the Recipes tab**
+
+Replace:
+
+```swift
+Tab("Recipes", systemImage: "list.bullet", value: TabSelection.recipes) {
+    NavigationStack { RecipesView() }
+}
+```
+
+With:
+
+```swift
+Tab("Stats", systemImage: "waveform.path.ecg", value: TabSelection.stats) {
+    NavigationStack { StatsView() }
+}
+```
+
+If `Shop` is already absent from the current tab list, add it back as:
+
+```swift
+Tab("Shop", systemImage: "sparkles", value: TabSelection.shop) {
+    NavigationStack { ShopView() }
+}
+```
+
+Keep the center add tab unchanged.
+
+- [ ] **Step 3: Build**
+
+Run:
+
+```bash
+xcodebuild -project BeanBook.xcodeproj -scheme BeanBook -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' build
+```
+
+Expected: build succeeds and the tab bar shows Today, Beans, Stats, Shop, plus the center add affordance.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add BeanBook/App/RootTabView.swift
+git commit -m "feat: replace recipes tab with stats"
+```
+
+---
+
+### Task 4: Surface Saved Recipes From Brews
+
+**Files:**
+- Modify: `BeanBook/Features/Brews/BrewListView.swift`
+
+- [ ] **Step 1: Add query and presentation state**
+
+Add near the existing brew query:
+
+```swift
+@Query(sort: \BrewPreset.createdAt, order: .reverse) private var presets: [BrewPreset]
+```
+
+Add state:
+
+```swift
+@State private var showRecipes = false
+```
+
+- [ ] **Step 2: Place the saved recipes entry**
+
+In the non-empty scroll stack, place `savedRecipesEntry` after `RecentShotsStrip` and before `list`.
+
+Use:
+
+```swift
+if !presets.isEmpty {
+    savedRecipesEntry
+        .padding(.horizontal, 24)
+        .padding(.top, recentBrews.count > 1 ? 22 : 24)
+}
+```
+
+- [ ] **Step 3: Implement the entry row**
+
+Add:
+
+```swift
+private var savedRecipesEntry: some View {
+    Button {
+        showRecipes = true
+    } label: {
+        VStack(spacing: 0) {
+            HairRule()
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Eyebrow("\(presets.count) saved")
+                    Text("Saved recipes")
+                        .font(.system(size: 22, weight: .medium, design: .serif))
+                        .tracking(-0.4)
+                        .foregroundStyle(Theme.ink)
+                    Text("Repeat what worked.")
+                        .font(Theme.body(12))
+                        .foregroundStyle(Theme.ink2)
+                }
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(Theme.ink3)
+            }
+            .padding(.vertical, 16)
+            HairRule()
+        }
+        .contentShape(.rect)
+    }
+    .buttonStyle(.plain)
+}
+```
+
+- [ ] **Step 4: Present existing RecipesView**
+
+Add a sheet:
+
+```swift
+.sheet(isPresented: $showRecipes) {
+    NavigationStack { RecipesView() }
+}
+```
+
+Keep existing `hotStartBrew` behavior intact.
+
+- [ ] **Step 5: Build**
+
+Run:
+
+```bash
+xcodebuild -project BeanBook.xcodeproj -scheme BeanBook -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add BeanBook/Features/Brews/BrewListView.swift
+git commit -m "feat: surface saved recipes from brews"
+```
+
+---
+
+### Task 5: Documentation Updates
+
+**Files:**
+- Modify: `docs/architecture.md`
+- Modify: `README.md`
+
+- [ ] **Step 1: Update architecture docs**
+
+In `docs/architecture.md`:
+
+- Update Root navigation to mention Today, Beans, Stats, Shop, and center add.
+- Add `Features/Stats/` section with `StatsView.swift` and `StatsSummary.swift`.
+- Update `Features/Recipes/` to say Recipes is no longer a tab and is surfaced from Brews.
+- Keep Pro positioning accurate: Stats is Pro-only; core logging remains free.
+
+- [ ] **Step 2: Update README**
+
+In `README.md`:
+
+- Add Stats to "What it does" as a Pro feature if the list mentions current app capabilities.
+- Do not overpromise beyond the V1 implementation.
+- Keep "one-time purchase" Pro copy unchanged.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/architecture.md README.md
+git commit -m "docs: document stats tab architecture"
+```
+
+---
+
+### Task 6: Final Verification
+
+**Files:**
+- Verify all changed files.
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+xcodebuild test -project BeanBook.xcodeproj -scheme BeanBook -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' -only-testing:BeanBookTests/StatsSummaryTests
+```
+
+Expected: `StatsSummaryTests` passes.
+
+- [ ] **Step 2: Run full build**
+
+Run:
+
+```bash
+xcodebuild -project BeanBook.xcodeproj -scheme BeanBook -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 3: Run project verification harness**
+
+Run:
+
+```bash
+./scripts/agent-verify.sh build
+```
+
+Expected: verification completes successfully.
+
+- [ ] **Step 4: Manual smoke checklist**
+
+On iPhone 17 Pro Max simulator:
+
+- Non-Pro user sees locked Stats with one-time purchase positioning.
+- Tap locked CTA and confirm `PaywallSheet` appears.
+- Pro/no-brews state shows `Nothing to show yet.` and `Log a brew`.
+- `Log a brew` opens `NewBrewSheet`.
+- Sparse data shows overview plus `More patterns appear as you log.` and `Logged so far`.
+- Populated data shows overview, activity strip, What's working, By bag, and Dial-in.
+- Brews screen shows `Saved recipes` when presets exist.
+- Tapping `Saved recipes` opens existing `RecipesView`.
+- Existing `Brew again` and recipe prefill behavior still opens `NewBrewSheet(prefill:)`.
+
+- [ ] **Step 5: Final status**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: clean working tree.

--- a/docs/superpowers/specs/2026-05-06-stats-tab-design.md
+++ b/docs/superpowers/specs/2026-05-06-stats-tab-design.md
@@ -1,0 +1,242 @@
+# Stats Tab - Design
+
+**Date:** 2026-05-06
+**Scope:** Replace the top-level Recipes tab with a Pro-gated Stats tab, and resurface saved recipes from Brews.
+
+## Goal
+
+Add a first-class Stats destination that shows what the user has brewed and what has been working. The feature should feel like a quiet personal ledger, not an analytics dashboard.
+
+Stats are a BeanBook Pro feature. The locked state must lead with one-time purchase positioning and make the value clear without turning the screen into vague marketing.
+
+## Non-goals
+
+- No social, comparison, leaderboard, or benchmark stats.
+- No streaks, goals, encouragement loops, or achievement language.
+- No global "coffee score" or generated performance judgment.
+- No Firebase, account, cloud sync, or backend dependency.
+- No rich charting library. V1 uses simple SwiftUI marks and rows.
+- No major Recipes rewrite. Existing `RecipesView` stays and moves behind a Brews entry point.
+
+## Navigation
+
+The main tabs become:
+
+1. Brews
+2. Bags
+3. Stats
+4. Shop
+
+The center "+" keeps its current behavior and still presents `NewBrewSheet`.
+
+`RecipesView` leaves the tab bar. Brews gets a `Saved recipes` entry point near the existing recent-shot area because saved recipes are primarily about repeating a brew. Tapping it opens the existing recipes list in a navigation destination or sheet, depending on the least invasive fit with current `BrewListView` navigation.
+
+## Stats states
+
+### Populated Pro
+
+This is the fully unlocked state for users with enough brew history.
+
+Header:
+
+- Eyebrow: rolling window metadata, such as `30 days / since Mar 27`
+- Optional small `Pro` chip
+- Title: `Stats`
+- Body: `A quiet ledger of what you've brewed and what's been working.`
+
+Overview:
+
+- Total brews in the window
+- Active bags in the window
+- Favorite method
+- Average rating
+
+Trend:
+
+- A compact last-30-days brew strip.
+- Bars show daily brew counts.
+- Labels are minimal: start date, today, and total count.
+- No goals or streak language.
+
+What is working:
+
+- Highest-rated recent brews.
+- Best bag by average rating once there is enough data.
+- Best saved recipe if recipes exist.
+- This section should answer "what should I brew again?"
+
+By bag:
+
+- Recent or active bags listed as compact rows.
+- Each row shows brew count, average rating, last brewed date, and a useful brew ratio or method summary.
+- V1 can stay inline. A bag stats detail screen is a later feature.
+
+Dial-in:
+
+- Focus on the current pinned bag when one exists; otherwise use the most recently brewed bag.
+- Show the last several espresso shots as `dose -> yield / time / rating`.
+- Subtle change indicators can show movement from shot to shot, but should not claim causation.
+
+### Locked non-Pro
+
+The locked state is a dedicated BeanBook Pro screen.
+
+Header:
+
+- Eyebrow: `BeanBook Pro`
+- Title: `Stats`
+- Body: `Stats are included with BeanBook Pro - a one-time purchase that also unlocks unlimited bags and exports.`
+
+Content:
+
+- Four short rows: Overview, What's working, By bag, Dial-in.
+- Each row has a number and one plain description.
+- CTA uses existing paywall/pro purchase flow and must include one-time purchase copy near the action.
+
+### Sparse data
+
+Sparse data appears when there are brews, but not enough history for meaningful patterns.
+
+Show:
+
+- The overview numbers that are available.
+- `Favorite method` as an em dash with `more data needed` when the sample is too small.
+- A simple card: `More patterns appear as you log.`
+- A `Logged so far` section with recent brew rows.
+
+Avoid hiding all content just because charts are not ready.
+
+### No brews
+
+The empty state is simple and direct.
+
+Title:
+
+- `Nothing to show yet.`
+
+Body:
+
+- `Log your first brew and patterns will start to appear here - what's working, by bag, dial-in.`
+
+CTA:
+
+- `Log a brew`
+- Uses the same new-brew presentation path as the center "+".
+
+## Data model and derivation
+
+Stats are derived from existing local SwiftData models:
+
+- `Brew`
+- `Bag`
+- `BrewPreset`
+
+No new stored model is required for V1.
+
+The Stats view should compute lightweight derived values from fetched local data:
+
+- Rolling 30-day brew count.
+- Active bags in the rolling window.
+- Favorite method by count.
+- Average rating among rated brews.
+- Daily brew counts for the chart strip.
+- Recent high-rated brews.
+- Bag summaries: brew count, average rating, last brewed date, method or ratio summary.
+- Dial-in rows for the pinned or most recent bag.
+
+Keep the derivation close to the feature unless it starts to spread. If the view becomes hard to read, introduce a small `StatsSummary` value type and a pure builder that can be unit tested.
+
+## Pro gating
+
+Stats are Pro-only, but the tab is visible to everyone.
+
+For non-Pro users:
+
+- Show the locked state.
+- Route purchase through the existing `PaywallSheet`.
+- Preserve Pro positioning: one-time purchase, unlimited everything, future Pro features included, Family Sharing where space allows.
+
+For Pro users:
+
+- Show stats immediately.
+- Do not show upsell copy inside populated stats.
+
+## Visual direction
+
+Follow the approved mock:
+
+- Editorial serif title.
+- Tiny uppercase metadata.
+- Hairline dividers.
+- Compact numeric overview.
+- Minimal charting.
+- Paper-like surfaces from `Theme.*`.
+- No busy dashboard grid.
+
+Use existing design primitives where possible:
+
+- `Theme.background`
+- `Theme.card`
+- `Theme.accent`
+- `Theme.accentSoft`
+- `Theme.rule`
+- `Eyebrow`
+- `HairRule`
+- Existing pill button styles
+
+The 30-day strip should be stable across small and large counts. Use a fixed-height row of bars and clamp bar height so one high-volume day does not flatten the rest of the chart into noise.
+
+## Copy
+
+Copy must follow `docs/branding.md`.
+
+Use:
+
+- `Stats`
+- `Overview`
+- `What's working`
+- `By bag`
+- `Dial-in`
+- `More patterns appear as you log.`
+- `Nothing to show yet.`
+- `Log a brew`
+
+Avoid:
+
+- `Insights`
+- `Performance`
+- `Score`
+- `Streak`
+- Celebration or praise copy
+
+## Error and edge handling
+
+- No brews: empty state.
+- One to two brews: sparse state.
+- No rated brews: show average rating as an em dash with `rate a brew to see this`.
+- No bag on a brew: exclude it from by-bag stats, but keep it in total brew counts.
+- No recipes: omit best recipe rows instead of showing a blank placeholder.
+- Non-espresso methods: include them in overview and by-bag summaries; dial-in can be espresso-first for V1.
+
+## Testing
+
+Automated:
+
+- Add focused Swift Testing coverage if a pure stats builder is introduced.
+- Cover empty, sparse, populated, unrated, and mixed-bag inputs.
+
+Manual:
+
+- Non-Pro account sees locked Stats with one-time purchase positioning.
+- Pro account with no brews sees the empty state and `Log a brew` opens `NewBrewSheet`.
+- Pro account with sparse brews sees available overview plus `Logged so far`.
+- Pro account with populated data sees overview, trend, what is working, by-bag, and dial-in.
+- Brews tab exposes saved recipes and opens the existing recipes screen.
+- Dynamic Type up to the app-supported limit does not overlap overview values, chart labels, or bottom tab content.
+
+## Risks
+
+- **Stats can feel too dashboard-heavy.** Mitigation: keep V1 to one compact overview, one trend strip, and editorial rows.
+- **Sample sizes can mislead.** Mitigation: sparse-state copy and thresholds before claiming best bag or favorite method.
+- **Recipes may become hidden.** Mitigation: place `Saved recipes` near recent brews, where repeat-brew behavior already lives.
+- **Stats derivation can bloat the view.** Mitigation: extract pure summary building once the view starts carrying nontrivial computation.


### PR DESCRIPTION
## Summary
- Adds a Pro-gated Stats tab with empty, sparse, and populated states for local brew insight.
- Adds a StatsSummary builder with coverage for overview metrics, 30-day activity, best bag, and dial-in rows.
- Replaces Recipes as a top-level tab and surfaces saved recipes from the Brews/Today screen.
- Updates architecture and README docs for the new navigation and stats surface.

## Test Plan
- `xcodebuild test -project BeanBook.xcodeproj -scheme BeanBook -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max'`
- `xcodebuild -project BeanBook.xcodeproj -scheme BeanBook -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' build`
- `./scripts/agent-verify.sh build`