### PR TITLE
fix(stats): remove dead ternary in total-brews caption

### DIFF
--- a/BeanBook/Features/Stats/StatsView.swift
+++ b/BeanBook/Features/Stats/StatsView.swift
@@ -282,7 +282,7 @@ private struct StatsOverviewGrid: View {
 
     var body: some View {
         LazyVGrid(columns: columns, alignment: .leading, spacing: 22) {
-            StatsMetric(value: "\(summary.totalBrews)", label: "Total brews", caption: summary.totalBrews == 1 ? "this month" : "this month")
+            StatsMetric(value: "\(summary.totalBrews)", label: "Total brews", caption: "this month")
             StatsMetric(value: "\(summary.activeBagCount)", label: "Active bags")
             StatsMetric(
                 value: summary.favoriteMethod?.displayName ?? "-",
@@ -517,34 +517,34 @@ private struct StatsProFeatureRow: View {
     let detail: String
     var showsRule = true
 
-	    var body: some View {
-	        VStack(spacing: 0) {
-	            HStack(alignment: .top, spacing: 22) {
-	                Text(number)
-	                    .font(Theme.body(11, weight: .bold))
-	                    .foregroundStyle(Theme.accent)
-	                    .monospacedDigit()
-	                    .frame(width: 28, alignment: .trailing)
-	                VStack(alignment: .leading, spacing: 4) {
-	                    Text(title)
-	                        .font(.system(size: 18, weight: .medium, design: .serif))
-	                        .tracking(-0.2)
-	                        .foregroundStyle(Theme.ink)
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(alignment: .top, spacing: 22) {
+                Text(number)
+                    .font(Theme.body(11, weight: .bold))
+                    .foregroundStyle(Theme.accent)
+                    .monospacedDigit()
+                    .frame(width: 28, alignment: .trailing)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(.system(size: 18, weight: .medium, design: .serif))
+                        .tracking(-0.2)
+                        .foregroundStyle(Theme.ink)
                     Text(detail)
                         .font(Theme.body(13))
-	                        .foregroundStyle(Theme.ink2)
-	                        .lineSpacing(2)
-	                }
-	                .frame(maxWidth: .infinity, alignment: .leading)
-	            }
-	            .frame(maxWidth: .infinity, alignment: .leading)
-	            .padding(.vertical, 16)
-	            if showsRule {
-	                HairRule()
-	                    .padding(.leading, 50)
-	            }
-	        }
-	    }
+                        .foregroundStyle(Theme.ink2)
+                        .lineSpacing(2)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 16)
+            if showsRule {
+                HairRule()
+                    .padding(.leading, 50)
+            }
+        }
+    }
 }
 
 private struct StatsEmptyCard: View {


### PR DESCRIPTION
## Summary

Reviewed the most recent commit (`94be679`) and found one low-confidence issue in `StatsView`.

### 🔍 Low confidence — needs review before merging

**`StatsOverviewGrid` — identical ternary branches in total-brews caption**

```swift
// before
StatsMetric(value: "\(summary.totalBrews)", label: "Total brews",
            caption: summary.totalBrews == 1 ? "this month" : "this month")

// after
StatsMetric(value: "\(summary.totalBrews)", label: "Total brews",
            caption: "this month")
```

Both ternary branches produced the same string, making the conditional dead code. There is no behavioural change — the displayed caption is identical. This is flagged as low confidence because the original intent may have been singular/plural differentiation (e.g. `"brew this month"` vs `"brews this month"`), in which case the caption strings rather than the conditional itself need updating.

Also cleaned up the inconsistent tab/space mixed indentation in `StatsProFeatureRow.body` that was introduced in the same commit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LYEucuTTmBrihA11C6G7VW)_