### PR TITLE
fix(stats): correct total brews caption to "last 30 days"

### DIFF
--- a/BeanBook/Features/Stats/StatsView.swift
+++ b/BeanBook/Features/Stats/StatsView.swift
@@ -282,7 +282,7 @@ private struct StatsOverviewGrid: View {
 
     var body: some View {
         LazyVGrid(columns: columns, alignment: .leading, spacing: 22) {
-            StatsMetric(value: "\(summary.totalBrews)", label: "Total brews", caption: "this month")
+            StatsMetric(value: "\(summary.totalBrews)", label: "Total brews", caption: "last 30 days")
             StatsMetric(value: "\(summary.activeBagCount)", label: "Active bags")
             StatsMetric(
                 value: summary.favoriteMethod?.displayName ?? "-",


### PR DESCRIPTION
## Acceptance Criteria

- [x] The "Total brews" metric on the Stats tab no longer reads "this month" when the underlying value is a 30-day rolling total.
- [x] Caption phrasing matches the chart label below it ("Brews / last 30 days") so the same window is described identically in both places.

## Verification

- [x] `./scripts/agent-verify.sh build` → **BUILD SUCCEEDED**
- [x] Manual: `StatsSummary.build` confirmed to compute `start = startOfToday - 29 days`, i.e. a 30-day rolling window — not a calendar-month window.

## Docs

- [x] Docs not needed because: pure copy correction inside one SwiftUI view; no architectural, branding, or design-token change. Existing branding voice ("plainspoken, specific") is preserved — "last 30 days" is more specific than "this month".

## Notes

Trivially small change but visibly user-facing. v1.02 just shipped the new Stats tab, so every Pro user opening it today would have seen "this month" attached to a 30-day rolling number. On May 8th, "this month" implies the May 1–8 window (8 days), which is materially different from the 30-day rolling total actually displayed — the kind of "this number feels wrong" trust hit worth avoiding on day one of a feature launch.

The fix is a one-line string replacement at [BeanBook/Features/Stats/StatsView.swift:285](BeanBook/Features/Stats/StatsView.swift#L285). Sibling label at line 343 already used the correct phrasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)