### PR TITLE
feat(stats): tap brew rows to open brew detail

### DIFF
--- a/BeanBook/Features/Stats/StatsView.swift
+++ b/BeanBook/Features/Stats/StatsView.swift
@@ -14,6 +14,10 @@ struct StatsView: View {
         StatsSummary.build(brews: brews, bags: bags, presets: presets)
     }
 
+    private var brewsByID: [PersistentIdentifier: Brew] {
+        Dictionary(uniqueKeysWithValues: brews.map { ($0.persistentModelID, $0) })
+    }
+
     var body: some View {
         ZStack {
             Theme.background.ignoresSafeArea()
@@ -36,6 +40,7 @@ struct StatsView: View {
         .sheet(isPresented: $showAddBrew) {
             NewBrewSheet()
         }
+        .navigationDestination(for: Brew.self) { BrewDetailView(brew: $0) }
     }
 
     private var lockedState: some View {
@@ -147,7 +152,7 @@ struct StatsView: View {
                         .padding(.top, 28)
                     VStack(spacing: 0) {
                         ForEach(summary.loggedSoFar) { row in
-                            StatsBrewRow(row: row)
+                            brewRowLink(for: row)
                         }
                     }
                 }
@@ -175,7 +180,7 @@ struct StatsView: View {
                         .padding(.top, 30)
                     VStack(spacing: 0) {
                         ForEach(summary.workingBrews) { row in
-                            StatsBrewRow(row: row)
+                            brewRowLink(for: row)
                         }
                         if let bestBag = summary.bestBag {
                             StatsBagRow(summary: bestBag, label: "Best bag")
@@ -269,6 +274,18 @@ struct StatsView: View {
     private func statsSectionHeader(_ title: String) -> some View {
         Eyebrow(title, color: Theme.accent)
             .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private func brewRowLink(for row: StatsSummary.BrewRow) -> some View {
+        if let brew = brewsByID[row.brewID] {
+            NavigationLink(value: brew) {
+                StatsBrewRow(row: row)
+            }
+            .buttonStyle(.plain)
+        } else {
+            StatsBrewRow(row: row)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Brew rows in the Stats tab ("What's working" and "Logged so far") are now tappable and push to `BrewDetailView`.
- Adds a small `brewsByID` lookup so the existing `StatsSummary.BrewRow.brewID` resolves back to the live `Brew` from the on-screen `@Query`.
- Registers `.navigationDestination(for: Brew.self)` on `StatsView` — each tab in `RootTabView` has its own `NavigationStack`, so destinations from `BrewListView`/`TodayView` don't carry over.

## Why
Stats rows were previously plain `VStack`s — non-interactive. After landing the stats UI, the natural next step is letting the user jump straight from a stat (e.g. a top-rated brew) into the brew to read notes or edit. Matches the pattern already used in `BrewListView`, `TodayView`, and `BagListView`.

## Notes for reviewers
- Scope is intentionally narrow: only `StatsBrewRow` is wrapped. `StatsDialInRow`, `StatsBagRow`, and `StatsInfoRow` are unchanged. (Dial-in rows also carry `brewID` if we want to extend the same treatment later.)
- Routes on the `Brew` model — not `PersistentIdentifier` — to stay consistent with every other navigation site in the app and keep `BrewDetailView(brew:)` as a single entry point.
- `brewRowLink(for:)` is `@ViewBuilder` with a fallback to a non-interactive row, in case a row references a brew that's been deleted between query refresh and tap.
- Uses `.buttonStyle(.plain)` to preserve the editorial row styling.

## Test plan
- [ ] Stats tab → "What's working": tap a row → opens `BrewDetailView` for that brew.
- [ ] Stats tab → "Logged so far" (sparse state, < 3 brews): tap a row → opens `BrewDetailView`.
- [ ] Back-swipe returns to Stats with scroll position preserved.
- [ ] Tapping a row whose brew was just deleted does nothing (no crash).
- [ ] `xcodebuild ... build` on iPhone 16 Pro / iOS 26.0 — verified locally: BUILD SUCCEEDED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)