### PR TITLE
Fix separator dot positioning in nearby roster row

### DIFF
--- a/BeanBook/Features/Shop/ShopView.swift
+++ b/BeanBook/Features/Shop/ShopView.swift
@@ -348,10 +348,10 @@ private struct NearbyRosterRow: View {
                             Text(loc)
                                 .font(Theme.body(11.5))
                                 .foregroundStyle(Theme.ink2)
+                            Text("·")
+                                .font(Theme.body(11.5))
+                                .foregroundStyle(Theme.ink3)
                         }
-                        Text("·")
-                            .font(Theme.body(11.5))
-                            .foregroundStyle(Theme.ink3)
                         Text(distanceLabel)
                             .font(Theme.body(11.5, weight: .semibold))
                             .foregroundStyle(Theme.accent)


### PR DESCRIPTION
## Description

Moved the separator dot (·) inside the HStack containing the location text in `NearbyRosterRow`. This ensures the dot is properly grouped with the location label rather than appearing as a separate element, improving layout consistency and alignment.

## Acceptance Criteria

- [x] Separator dot is positioned immediately after location text
- [x] Visual layout matches design intent

## Verification

- [ ] `./scripts/agent-verify.sh preflight`
- [ ] Build and verify the nearby roster row displays correctly with proper spacing between location and distance labels

## Docs

- [x] Docs not needed because: This is a UI layout fix with no API or behavioral changes

## Notes

This is a minor layout adjustment to the shop view's nearby roster display.

https://claude.ai/code/session_019qzTZpUDqE19CSmEq5Nffd