### PR TITLE
fix(brews): use Theme.accent for ratio in BrewListRow

### DIFF
--- a/BeanBook/Features/Brews/BrewListView.swift
+++ b/BeanBook/Features/Brews/BrewListView.swift
@@ -179,7 +179,7 @@ private struct BrewListRow: View {
                     RatioText(brew.ratio)
                         .font(.system(size: 16, weight: .medium, design: .serif))
                         .monospacedDigit()
-                        .foregroundStyle(Theme.ink)
+                        .foregroundStyle(Theme.accent)
                     if let r = brew.rating, r > 0 {
                         RatingDots(value: r, size: 5)
                     }


### PR DESCRIPTION
## Summary
- `BrewListRow` was rendering the brew ratio in `Theme.ink`, while `TodayBrewRow` ([TodayView.swift:231](BeanBook/Features/Today/TodayView.swift#L231)) and `StatsBrewRow` ([StatsView.swift:425](BeanBook/Features/Stats/StatsView.swift#L425)) both use `Theme.accent` for the same field.
- The ratio is the primary at-a-glance number in every brew row; the muted color in the list made it recede into supporting metadata and broke the visual link between Today, Stats, and the full brew list.
- One-line change in [BrewListView.swift:182](BeanBook/Features/Brews/BrewListView.swift#L182): `Theme.ink` → `Theme.accent`.

## Test plan
- [x] `xcodebuild ... build` succeeds (BUILD SUCCEEDED on iPhone 16 Pro / iOS 26.0).
- [ ] Visually confirm the ratio in the brew list (Today → "show all brews" sheet) now reads in the warm accent tone, matching Today and Stats rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)