### PR TITLE
fix(brews/bags): ratio accent color + stale filter guard

### DIFF
--- a/BeanBook/Features/Bags/BagDetailView.swift
+++ b/BeanBook/Features/Bags/BagDetailView.swift
@@ -228,7 +228,7 @@ private struct BagBrewRow: View {
                     RatioText(brew.ratio)
                         .font(.system(size: 17, weight: .medium, design: .serif))
                         .monospacedDigit()
-                        .foregroundStyle(Theme.ink)
+                        .foregroundStyle(Theme.accent)
                 }
             }
             .padding(.vertical, 14)

--- a/BeanBook/Features/Brews/BrewListView.swift
+++ b/BeanBook/Features/Brews/BrewListView.swift
@@ -110,6 +110,12 @@ struct BrewListView: View {
         }
         .navigationDestination(for: Brew.self) { BrewDetailView(brew: $0) }
         .navigationDestination(for: Bag.self) { BagDetailView(bag: $0) }
+        .onChange(of: brews.count) { _, newCount in
+            if newCount < 5 {
+                methodFilter = nil
+                bagFilter = nil
+            }
+        }
     }
 
     private var header: some View {


### PR DESCRIPTION
## Summary

Two bugs found while reviewing the commits merged on 2026-05-09.

---

### ✅ High confidence — `BagDetailView.swift`

**`BagBrewRow` ratio uses `Theme.ink` instead of `Theme.accent`**

PR #12 fixed `BrewListRow`'s ratio color with the note:
> "both `TodayBrewRow` and `StatsBrewRow` render it in `Theme.accent`"

`BagBrewRow` was the missed fourth surface — same one-liner fix, same reasoning. Every brew-row in the app now uses `Theme.accent` for the ratio.

---

### ⚠️ Lower confidence — `BrewListView.swift`

**Stale filter state when brew count drops below the 5-entry threshold**

`showsFilters` gates the filter chip row on `brews.count >= 5`. If a user applies a method or bag filter and then deletes enough brews to go below that threshold, the chips disappear but `methodFilter`/`bagFilter` remain set in `@State`. `filteredBrews` still applies the filter silently — the list shows fewer entries than exist with no visible explanation.

**Fix:** `.onChange(of: brews.count)` clears both filters when the count drops below 5.

**Why lower confidence:** The trigger (having ≥5 brews, applying filters, then deleting down to <5) is an unusual path. The fix is safe and minimal, but worth a quick read before merging.

## Test plan

- [ ] Open bag detail, verify ratio text is now accent-colored in the brew list rows
- [ ] Confirm `TodayBrewRow`, `StatsBrewRow`, `BrewListRow`, and `BagBrewRow` all render ratio in the same accent color
- [ ] Add 5+ brews, apply a method filter, delete brews until fewer than 5 remain — verify filter chips and filter state are both cleared
- [ ] Normal filter usage (≥5 brews) still works as before

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cutc2xmwcBFDgtovCj5q2H)_