### PR TITLE
chore: bump marketing version to 1.03

### DIFF
--- a/BeanBook.xcodeproj/project.pbxproj
+++ b/BeanBook.xcodeproj/project.pbxproj
@@ -410,7 +410,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = BeanBook/BeanBook.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_ASSET_PATHS = "\"BeanBook/Preview Content\"";
 				DEVELOPMENT_TEAM = 5Z6AC3LV9L;
 				ENABLE_PREVIEWS = YES;
@@ -427,7 +427,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.02;
+				MARKETING_VERSION = 1.03;
 				PRODUCT_BUNDLE_IDENTIFIER = duhmarcus.BeanBook;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -443,7 +443,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = BeanBook/BeanBook.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_ASSET_PATHS = "\"BeanBook/Preview Content\"";
 				DEVELOPMENT_TEAM = 5Z6AC3LV9L;
 				ENABLE_PREVIEWS = YES;
@@ -460,7 +460,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.02;
+				MARKETING_VERSION = 1.03;
 				PRODUCT_BUNDLE_IDENTIFIER = duhmarcus.BeanBook;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;


### PR DESCRIPTION
## Summary

Prepares the App Store submission for **1.03**.

- `MARKETING_VERSION` 1.02 → **1.03** on the BeanBook target (Debug + Release)
- `CURRENT_PROJECT_VERSION` 1 → **2** to satisfy App Store Connect's unique-build-number requirement

Release build was verified locally on iPhone 16 Pro / iOS 26.0 before pushing.

## Changes since 1.02

Non-merge commits in `94be679..HEAD` that ship in this version:

**Features**
- 5a5c47d feat(brews): method and bag filter chips in `BrewListView`
- 585311e feat(stats): tap brew rows to open brew detail
- af99a10 feat: simplify `BigRatio` animation, enhance landing page layout

**Fixes**
- 2343eb9 fix(brews): `Theme.accent` for ratio in `BrewListRow`
- 48562c6 fix(shop): guard dot separator when location label is absent
- b0252c4 fix(stats): correct total brews caption to "last 30 days"
- bf677fa fix(stats): remove dead ternary in caption

**Cleanup**
- 71580eb Remove Firebase Functions implementation and related configurations
- ad7078e Remove Shop Done button from main tab

## App Store "What's New" copy

```
Filter your brew log by method and bag from the All Brews sheet.

Tap any brew in Stats to open its detail.

Smoother ratio animation and a cleaner landing page.

Small fixes: Stats now reads "last 30 days," and Shop no longer shows a stray dot when a roaster has no location label.
```

## Test plan

- [x] `xcodebuild ... -configuration Release build` succeeds on iPhone 16 Pro / iOS 26.0
- [ ] Archive + upload to App Store Connect succeeds
- [ ] TestFlight build appears with version 1.03 (2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)