### PR TITLE
fix: replace deprecated Text + Text concatenation (iOS 26)

### DIFF
--- a/BeanBook/Features/Bags/BagDetailView.swift
+++ b/BeanBook/Features/Bags/BagDetailView.swift
@@ -114,16 +114,15 @@ struct BagDetailView: View {
     }
 
     private var tastingNotes: some View {
-        let parts = Array(bag.tastingNotes.enumerated())
-        return parts.reduce(into: Text("")) { acc, pair in
-            let (i, n) = pair
-            if i > 0 {
-                acc = acc + Text(" · ").foregroundStyle(Theme.accent)
-            }
-            acc = acc + Text(n).foregroundStyle(Theme.ink)
+        var acc = Text("")
+        for (i, n) in bag.tastingNotes.enumerated() {
+            let separator = i > 0 ? Text(" · ").foregroundStyle(Theme.accent) : Text("")
+            let note = Text(n).foregroundStyle(Theme.ink)
+            acc = Text("\(acc)\(separator)\(note)")
         }
-        .font(.system(size: 24, weight: .regular, design: .serif))
-        .tracking(-0.4)
+        return acc
+            .font(.system(size: 24, weight: .regular, design: .serif))
+            .tracking(-0.4)
     }
 
     private func descriptionBlock(_ notes: String) -> some View {

--- a/BeanBook/Features/Bags/NewBagSheet.swift
+++ b/BeanBook/Features/Bags/NewBagSheet.swift
@@ -206,13 +206,10 @@ private struct IdentitySection: View {
         VStack(alignment: .leading, spacing: 20) {
             Eyebrow("Identity", color: Theme.ink2)
 
-            (Text("What did you ")
-                .foregroundStyle(Theme.ink)
-             + Text("open")
-                .foregroundStyle(Theme.accent)
-                .italic()
-             + Text("?")
-                .foregroundStyle(Theme.accent))
+            let prefix = Text("What did you ").foregroundStyle(Theme.ink)
+            let verb = Text("open").foregroundStyle(Theme.accent).italic()
+            let punct = Text("?").foregroundStyle(Theme.accent)
+            Text("\(prefix)\(verb)\(punct)")
                 .font(Theme.display(34, weight: .semibold))
                 .lineSpacing(2)
 

--- a/BeanBook/Shared/SharedViews/BigRatio.swift
+++ b/BeanBook/Shared/SharedViews/BigRatio.swift
@@ -81,9 +81,8 @@ struct RatioBar: View {
 @MainActor
 func RatioText(_ ratio: Double) -> Text {
     let val = ratio.formatted(.number.precision(.fractionLength(2)))
-    return Text("1")
-        + Text(":").fontWeight(.bold).foregroundStyle(Theme.accent)
-        + Text(val)
+    let colon = Text(":").fontWeight(.bold).foregroundStyle(Theme.accent)
+    return Text("1\(colon)\(val)")
 }
 
 private extension HorizontalAlignment {


### PR DESCRIPTION
## Summary

- iOS 26 deprecates `Text + Text` concatenation in favor of string interpolation (`Text(\"\(a)\(b)\")`), which preserves per-segment styling (`foregroundStyle`, `fontWeight`, `italic`).
- Clears all 6 build warnings flagged in App Store Connect prep across 3 files.

## Changes

- [BagDetailView.swift:116-126](BeanBook/Features/Bags/BagDetailView.swift) — `tastingNotes` reducer now interpolates the running `Text` with the dot separator and each note instead of `+`-chaining them.
- [BigRatio.swift:82-87](BeanBook/Shared/SharedViews/BigRatio.swift) — `RatioText("1:X.XX")` now interpolates the bold/accent-tinted colon Text into a single `Text` literal.
- [NewBagSheet.swift:209-214](BeanBook/Features/Bags/NewBagSheet.swift) — "What did you open?" headline is built with three styled `Text` locals interpolated together; the parenthesized `+` chain is gone.

## Notes

- Behavior and visual output are unchanged — the Text values still carry the same `foregroundStyle` / `italic` / `fontWeight` modifiers; only the composition syntax changed.
- The "Preparing build for App Store Connect failed" error in the screenshot is from Organizer archive validation and is **not** related to these warnings; it'll need a separate look once the archive's actual error message is captured.

## Test plan

- [x] `xcodebuild build` for iPhone 16 Pro / iOS 26.0 — `BUILD SUCCEEDED`
- [x] No remaining `'+' was deprecated in iOS 26.0` warnings on any of the three files
- [ ] Visual check: tasting-note dot separators in Bag detail, `1:2.00` ratio glyph, NewBagSheet headline

🤖 Generated with [Claude Code](https://claude.com/claude-code)