### PR TITLE
feat(brews): add search to brew list

### DIFF
--- a/BeanBook/Features/Brews/BrewListView.swift
+++ b/BeanBook/Features/Brews/BrewListView.swift
@@ -14,16 +14,41 @@ struct BrewListView: View {
     @State private var hotStartBrew: Brew?
     @State private var methodFilter: BrewMethod? = nil
     @State private var bagFilter: Bag? = nil
+    @State private var searchText = ""
     @Namespace private var addSheetNamespace
 
     private var recentBrews: [Brew] { Array(brews.prefix(5)) }
 
+    private var trimmedSearch: String {
+        searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var isSearching: Bool { !trimmedSearch.isEmpty }
+
     private var filteredBrews: [Brew] {
-        brews.filter { brew in
+        let needle = trimmedSearch.lowercased()
+        return brews.filter { brew in
             if let methodFilter, brew.method != methodFilter { return false }
             if let bagFilter, brew.bag?.persistentModelID != bagFilter.persistentModelID { return false }
+            if !needle.isEmpty, !matches(brew, needle: needle) { return false }
             return true
         }
+    }
+
+    /// Case-insensitive substring match across the fields a user is most likely
+    /// to remember a brew by: notes, the bag's brand/name/tasting-notes, the
+    /// method's display name, and the grind setting.
+    private func matches(_ brew: Brew, needle: String) -> Bool {
+        if let notes = brew.notes, notes.lowercased().contains(needle) { return true }
+        if brew.method.displayName.lowercased().contains(needle) { return true }
+        if let grind = brew.grindSetting, grind.lowercased().contains(needle) { return true }
+        if let bag = brew.bag {
+            if bag.brand.lowercased().contains(needle) { return true }
+            if bag.name.lowercased().contains(needle) { return true }
+            if bag.origin.lowercased().contains(needle) { return true }
+            if bag.tastingNotes.contains(where: { $0.lowercased().contains(needle) }) { return true }
+        }
+        return false
     }
 
     /// Distinct bags referenced by any brew, in most-recent-brew order.
@@ -41,7 +66,7 @@ struct BrewListView: View {
         return result
     }
 
-    private var hasActiveFilter: Bool { methodFilter != nil || bagFilter != nil }
+    private var hasActiveFilter: Bool { methodFilter != nil || bagFilter != nil || isSearching }
     private var showsFilters: Bool { brews.count >= 5 }
 
     var body: some View {
@@ -54,18 +79,18 @@ struct BrewListView: View {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 0) {
                         header
-                        if recentBrews.count > 1 {
+                        if !isSearching, recentBrews.count > 1 {
                             RecentShotsStrip(brews: recentBrews) { brew in
                                 hotStartBrew = brew
                             }
                             .padding(.top, 24)
                         }
-                        if !presets.isEmpty {
+                        if !isSearching, !presets.isEmpty {
                             savedRecipesEntry
                                 .padding(.horizontal, 24)
                                 .padding(.top, recentBrews.count > 1 ? 22 : 24)
                         }
-                        if showsFilters {
+                        if !isSearching, showsFilters {
                             filterChips
                                 .padding(.top, 28)
                         }
@@ -83,6 +108,11 @@ struct BrewListView: View {
         }
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(.hidden, for: .navigationBar)
+        .searchable(
+            text: $searchText,
+            placement: .navigationBarDrawer(displayMode: .automatic),
+            prompt: "Search notes, bag, method, grind"
+        )
         .toolbar {
             ToolbarItem(placement: .cancellationAction) {
                 Button("Done") { dismiss() }
@@ -245,13 +275,14 @@ struct BrewListView: View {
 
     private var filteredEmptyState: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("No brews match.")
+            Text(isSearching ? "No matches for \u{201C}\(trimmedSearch)\u{201D}." : "No brews match.")
                 .font(.system(size: 22, weight: .medium, design: .serif))
                 .tracking(-0.4)
                 .foregroundStyle(Theme.ink)
-            Button("Clear filters") {
+            Button(isSearching && (methodFilter == nil && bagFilter == nil) ? "Clear search" : "Clear filters") {
                 methodFilter = nil
                 bagFilter = nil
+                searchText = ""
             }
             .buttonStyle(.outlinePill)
         }


### PR DESCRIPTION
## Summary

Adds a `.searchable` field to BrewListView so users can find a specific brew by typing instead of scrolling. Past ~50 entries, the existing method/bag chip filters don't help when you're hunting for a specific date, grind, or tasting note.

The search matches case-insensitively against:
- brew notes
- method display name (e.g. "Espresso", "Pour Over")
- grind setting
- linked bag's brand, name, origin, and tasting notes

Filters in-memory over the existing `@Query` result and intersects with the existing method/bag chip filters. Recent-shots strip, saved-recipes entry, and chip rows hide while searching to focus the view on results.

## Acceptance Criteria

- [x] Search field appears in the navigation bar drawer of BrewListView
- [x] Typing filters the list in real time
- [x] Search intersects with method/bag chip filters when both are active
- [x] Empty state distinguishes "No matches for `<query>`" from "No brews match"
- [x] Clear button label adapts: "Clear search" when only search is active, "Clear filters" when chips are also engaged
- [x] Recent-shots strip / saved-recipes entry / chip rows hide while searching

## Verification

- [x] `xcodebuild build` — `** BUILD SUCCEEDED **` on iPhone 16 Pro / iOS 26.0
- [x] `xcodebuild test -only-testing:BeanBookTests` — all 12 tests pass

## Docs

- [x] Docs not needed because: feature is a discoverable surface change in an existing screen — no new architectural pattern, no new component, no change to brand voice or design tokens. `branding.md` and `design.md` are unaffected.

## Notes

The proposal also asked for a "Brew Again" button on brew detail. That feature already shipped — [BrewDetailView.swift:146-160](BeanBook/Features/Brews/BrewListView.swift) has a primary-pill "Brew this again" that presents `NewBrewSheet(prefill: brew)`. No work to do there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)