### PR TITLE
fix(brews): skip chip filters during search + clarify empty-state label

### DIFF
--- a/BeanBook/Features/Brews/BrewListView.swift
+++ b/BeanBook/Features/Brews/BrewListView.swift
@@ -28,8 +28,12 @@ struct BrewListView: View {
     private var filteredBrews: [Brew] {
         let needle = trimmedSearch.lowercased()
         return brews.filter { brew in
-            if let methodFilter, brew.method != methodFilter { return false }
-            if let bagFilter, brew.bag?.persistentModelID != bagFilter.persistentModelID { return false }
+            // Chip filters are hidden while the search bar is active, so skip
+            // them here — search always scans the full brew list.
+            if !isSearching {
+                if let methodFilter, brew.method != methodFilter { return false }
+                if let bagFilter, brew.bag?.persistentModelID != bagFilter.persistentModelID { return false }
+            }
             if !needle.isEmpty, !matches(brew, needle: needle) { return false }
             return true
         }
@@ -279,7 +283,7 @@ struct BrewListView: View {
                 .font(.system(size: 22, weight: .medium, design: .serif))
                 .tracking(-0.4)
                 .foregroundStyle(Theme.ink)
-            Button(isSearching && (methodFilter == nil && bagFilter == nil) ? "Clear search" : "Clear filters") {
+            Button(isSearching ? "Clear search" : "Clear filters") {
                 methodFilter = nil
                 bagFilter = nil
                 searchText = ""
@@ -376,7 +380,7 @@ private struct BrewListRow: View {
     }
 
     private var detail: String {
-        let bag = brew.bag?.brand ?? "—"
+        let bag = brew.bag?.brand ?? "\u{2014}"
         let date = brew.createdAt.formatted(.relative(presentation: .numeric))
         return "\(bag) · \(date)"
     }


### PR DESCRIPTION
## Summary

- `filteredBrews` now skips `methodFilter`/`bagFilter` when `isSearching = true`, so search always scans the full brew list
- `filteredEmptyState` button label simplified from a misleading three-way ternary to `isSearching ? "Clear search" : "Clear filters"`

## Bug

Merged in PR #17: the chip filter rows are hidden behind `if !isSearching, showsFilters { ... }`, but `filteredBrews` still applied `methodFilter`/`bagFilter` while the search bar was active. A user with an active chip filter (e.g. "V60 only") who then opened the search bar would silently see a pre-filtered result set with no UI indication — the filter chips were invisible but still cutting results.

The empty-state button label compounded this: it could show "Clear filters" when no filter chips were visible (because `isSearching` was true), leaving users confused about what to tap.

## Fix

```swift
// filteredBrews — chip filters are hidden during search, so skip them:
if !isSearching {
    if let methodFilter, brew.method != methodFilter { return false }
    if let bagFilter, brew.bag?.persistentModelID != bagFilter.persistentModelID { return false }
}

// empty-state label — straightforward now:
Button(isSearching ? "Clear search" : "Clear filters") { … }
```

## Test plan

- [ ] Set a method chip filter → brews filter correctly
- [ ] Activate search bar with chip filter active → search scans **all** brews (chip filter inactive)
- [ ] Dismiss search bar → chip filter resumes
- [ ] Empty-state with active search shows "Clear search"; with chip filter shows "Clear filters"

https://claude.ai/code/session_011JM23T4s5oFsoCbB9uXrC7

---
_Generated by [Claude Code](https://claude.ai/code/session_011JM23T4s5oFsoCbB9uXrC7)_