### PR TITLE
fix(brews): correct clear button label when search and filters are both active

### DIFF
--- a/BeanBook/Features/Brews/BrewListView.swift
+++ b/BeanBook/Features/Brews/BrewListView.swift
@@ -279,7 +279,7 @@ struct BrewListView: View {
                 .font(.system(size: 22, weight: .medium, design: .serif))
                 .tracking(-0.4)
                 .foregroundStyle(Theme.ink)
-            Button(isSearching && (methodFilter == nil && bagFilter == nil) ? "Clear search" : "Clear filters") {
+            Button(isSearching && methodFilter == nil && bagFilter == nil ? "Clear search" : (isSearching ? "Clear all" : "Clear filters")) {
                 methodFilter = nil
                 bagFilter = nil
                 searchText = ""


### PR DESCRIPTION
## Summary

- Found in reviewing the search feature added in the recent `feat(brews): add search to brew list` commit.

### ⚠️ Medium confidence — please review

**`filteredEmptyState` button label is misleading when both search text and a method/bag filter are active**

The original ternary:
```swift
isSearching && (methodFilter == nil && bagFilter == nil) ? "Clear search" : "Clear filters"
```

Evaluated to `"Clear filters"` whenever the first condition was false — including the case where the user _was_ searching but also had a chip filter selected. In that state the button cleared _both_ (correct behavior) but the label implied only the filter chips would be reset, suggesting the search text would be preserved.

**Fix:** Add a third label `"Clear all"` for the combined case:

| State | Old label | New label |
|---|---|---|
| Search only | "Clear search" | "Clear search" ✓ |
| Filters only | "Clear filters" | "Clear filters" ✓ |
| Search + filters | "Clear filters" ✗ | "Clear all" ✓ |

The tap action is unchanged — it still clears everything.

## Test plan

- [ ] Enter a search query with no filters → empty state shows "Clear search"
- [ ] Activate a method or bag filter with no search → empty state shows "Clear filters"
- [ ] Activate a filter AND enter a search query that yields no results → empty state shows "Clear all"
- [ ] Tapping "Clear all" clears both the search bar and the filter chip selection

---
_Generated by [Claude Code](https://claude.ai/code/session_01FXrzEQb9s6BPZiBbUjc7Y9)_