### PR TITLE
fix(brews/recipes): 4 high-confidence bugs — dangling bagFilter, hidden filter+search, stray separator, misleading totalUses

### DIFF
--- a/BeanBook/Features/Brews/BrewDetailView.swift
+++ b/BeanBook/Features/Brews/BrewDetailView.swift
@@ -72,7 +72,7 @@ struct BrewDetailView: View {
             if let bag = brew.bag {
                 NavigationLink(value: bag) {
                     HStack(spacing: 4) {
-                        Text("\(bag.brand) · \(bag.name)")
+                        Text(bag.displayTitle)
                             .font(Theme.body(13.5, weight: .medium))
                             .foregroundStyle(Theme.accent)
                         Image(systemName: "arrow.up.right")

--- a/BeanBook/Features/Brews/BrewListView.swift
+++ b/BeanBook/Features/Brews/BrewListView.swift
@@ -13,7 +13,7 @@ struct BrewListView: View {
     @State private var showRecipes = false
     @State private var hotStartBrew: Brew?
     @State private var methodFilter: BrewMethod? = nil
-    @State private var bagFilter: Bag? = nil
+    @State private var bagFilterID: PersistentIdentifier? = nil
     @State private var searchText = ""
     @Namespace private var addSheetNamespace
 
@@ -29,7 +29,7 @@ struct BrewListView: View {
         let needle = trimmedSearch.lowercased()
         return brews.filter { brew in
             if let methodFilter, brew.method != methodFilter { return false }
-            if let bagFilter, brew.bag?.persistentModelID != bagFilter.persistentModelID { return false }
+            if let bagFilterID, brew.bag?.persistentModelID != bagFilterID { return false }
             if !needle.isEmpty, !matches(brew, needle: needle) { return false }
             return true
         }
@@ -66,7 +66,7 @@ struct BrewListView: View {
         return result
     }
 
-    private var hasActiveFilter: Bool { methodFilter != nil || bagFilter != nil || isSearching }
+    private var hasActiveFilter: Bool { methodFilter != nil || bagFilterID != nil || isSearching }
     private var showsFilters: Bool { brews.count >= 5 }
 
     var body: some View {
@@ -143,7 +143,18 @@ struct BrewListView: View {
         .onChange(of: brews.count) { _, newCount in
             if newCount < 5 {
                 methodFilter = nil
-                bagFilter = nil
+                bagFilterID = nil
+            }
+        }
+        .onChange(of: bagsInBrews) { _, newBags in
+            if let bagFilterID, !newBags.contains(where: { $0.persistentModelID == bagFilterID }) {
+                self.bagFilterID = nil
+            }
+        }
+        .onChange(of: isSearching) { _, nowSearching in
+            if nowSearching {
+                methodFilter = nil
+                bagFilterID = nil
             }
         }
     }
@@ -246,16 +257,16 @@ struct BrewListView: View {
                         FilterChip(
                             label: "All bags",
                             symbol: nil,
-                            selected: bagFilter == nil
-                        ) { bagFilter = nil }
+                            selected: bagFilterID == nil
+                        ) { bagFilterID = nil }
 
                         ForEach(bagsInBrews, id: \.persistentModelID) { bag in
                             FilterChip(
                                 label: bagChipLabel(for: bag),
                                 symbol: nil,
-                                selected: bagFilter?.persistentModelID == bag.persistentModelID
+                                selected: bagFilterID == bag.persistentModelID
                             ) {
-                                bagFilter = (bagFilter?.persistentModelID == bag.persistentModelID) ? nil : bag
+                                bagFilterID = (bagFilterID == bag.persistentModelID) ? nil : bag.persistentModelID
                             }
                         }
                     }
@@ -279,9 +290,9 @@ struct BrewListView: View {
                 .font(.system(size: 22, weight: .medium, design: .serif))
                 .tracking(-0.4)
                 .foregroundStyle(Theme.ink)
-            Button(isSearching && (methodFilter == nil && bagFilter == nil) ? "Clear search" : "Clear filters") {
+            Button(isSearching && (methodFilter == nil && bagFilterID == nil) ? "Clear search" : "Clear filters") {
                 methodFilter = nil
-                bagFilter = nil
+                bagFilterID = nil
                 searchText = ""
             }
             .buttonStyle(.outlinePill)

--- a/BeanBook/Features/Recipes/RecipesView.swift
+++ b/BeanBook/Features/Recipes/RecipesView.swift
@@ -8,8 +8,6 @@ struct RecipesView: View {
 
     @State private var prefillBrew: Brew?
 
-    private var totalUses: Int { presets.count }
-
     var body: some View {
         ZStack {
             Theme.background.ignoresSafeArea()
@@ -38,7 +36,7 @@ struct RecipesView: View {
 
     private var header: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Eyebrow("\(presets.count) saved · used \(totalUses) times")
+            Eyebrow("\(presets.count) saved")
             Text("Recipes")
                 .font(.system(size: 36, weight: .medium, design: .serif))
                 .tracking(-1)


### PR DESCRIPTION
## Summary

Four high-confidence bugs found during automated review of recent commits.

- **`BrewListView`** — `bagFilter: Bag?` held a direct SwiftData model reference; if the user set a bag filter then deleted that bag (via `BagDetailView`), accessing `.persistentModelID` on the invalidated object could crash or silently empty the list. Changed to `bagFilterID: PersistentIdentifier?`.
- **`BrewListView`** — chip filters were not cleared when the search bar was activated. An active `methodFilter` or `bagFilter` would silently compound with the search query; the chip row was hidden so the user had no way to see or clear the extra constraint. Added `.onChange(of: isSearching)` that resets both filters on search start.
- **`BrewListView`** — added `.onChange(of: bagsInBrews)` that clears `bagFilterID` if the filtered bag is no longer present in any brew (deleted or all brews removed).
- **`BrewDetailView`** — `"\(bag.brand) · \(bag.name)"` produced stray leading/trailing ` · ` separators when only one of brand/name was populated. Replaced with `bag.displayTitle`, which already handles all three cases correctly.
- **`RecipesView`** — `totalUses` was always `presets.count`, making the eyebrow read e.g. "3 saved · used 3 times" — always the same number twice. Removed the property and simplified the eyebrow to "N saved".

## Test plan

- [ ] Set a bag filter chip, navigate to `BagDetailView`, delete the bag — leaderboard should show all brews (not crash or show empty)
- [ ] Set a method or bag chip filter, then tap the search bar — chip filters should reset and the search should show results from all brews
- [ ] Open a brew whose bag has only `brand` or only `name` filled — detail header should show the single value without a stray ` · `
- [ ] Open Recipes tab — eyebrow should read "N saved" without a "used N times" suffix

## Lower-confidence issues (not fixed — needs product decision)

The following were found at **MEDIUM** or **LOW** confidence and left for review:

**MEDIUM** — `filteredEmptyState` button label: when both search and a chip filter are active simultaneously, the button text should say "Clear all" but currently shows "Clear filters" (the `isSearching && (methodFilter == nil && bagFilterID == nil)` condition). Minor UX confusion, not a crash.

**LOW** — `StatsView.statsEyebrow` day count: computes `dateComponents(.day, from: windowStart, to: windowEnd).day + 1` dynamically. Near midnight this can read "31 days" for a window that is always exactly 30 days. Cosmetic, extremely rare.

---
_Generated by [Claude Code](https://claude.ai/code/session_011eonsKDgfaWUPPGggK3Dyo)_