### PR TITLE
fix(brews): replace guarded force-unwrap in BrewDetailView grind row

### DIFF
--- a/BeanBook/Features/Brews/BrewDetailView.swift
+++ b/BeanBook/Features/Brews/BrewDetailView.swift
@@ -137,7 +137,7 @@ struct BrewDetailView: View {
             if let temp = brew.waterTempC {
                 RuleRow("Water", value: "\(Int(temp))°C")
             }
-            RuleRow("Grind", value: brew.grindSetting?.isEmpty == false ? brew.grindSetting! : "—")
+            RuleRow("Grind", value: brew.grindSetting?.isEmpty == false ? brew.grindSetting ?? "—" : "—")
         }
         .padding(.horizontal, 28)
         .padding(.top, Theme.p(36))


### PR DESCRIPTION
## Summary\n\n- `BrewDetailView.params`: `brew.grindSetting!` was force-unwrapped inside a ternary whose condition (`brew.grindSetting?.isEmpty == false`) already guaranteed the optional was non-nil. The unwrap couldn't crash in practice, but the compiler had no way to verify that, and static-analysis tools flag it. Replaced with `?? \"—\"` so nil-safety is compiler-verified.\n\n## Test plan\n\n- [ ] Open a brew with a grind setting — confirm the value displays correctly\n- [ ] Open a brew with no grind setting — confirm \"—\" displays\n- [ ] Open a brew whose grind setting was saved as an empty string — confirm \"—\" displays\n\nhttps://claude.ai/code/session_01YM6mvABK32JfDW1q9Q2fkT

---
_Generated by [Claude Code](https://claude.ai/code/session_01YM6mvABK32JfDW1q9Q2fkT)_