### PR TITLE
fix(brew-detail): remove force unwrap on grindSetting display

### DIFF
--- a/BeanBook/Features/Brews/BrewDetailView.swift
+++ b/BeanBook/Features/Brews/BrewDetailView.swift
@@ -137,7 +137,7 @@ struct BrewDetailView: View {
             if let temp = brew.waterTempC {
                 RuleRow("Water", value: "\(Int(temp))°C")
             }
-            RuleRow("Grind", value: brew.grindSetting?.isEmpty == false ? brew.grindSetting! : "—")
+            RuleRow("Grind", value: brew.grindSetting?.isEmpty == false ? brew.grindSetting ?? "—" : "—")
         }
         .padding(.horizontal, 28)
         .padding(.top, Theme.p(36))


### PR DESCRIPTION
## Summary

- Replace `brew.grindSetting!` with `brew.grindSetting ?? "—"` in `BrewDetailView.params` (line 140). The ternary condition already guards against nil, so the force unwrap was redundant — but if the guard expression ever drifts (e.g. a future refactor removes the `?.isEmpty == false` check), it becomes a latent crash. Using `??` makes the fallback explicit and safe unconditionally.

## What was reviewed

Reviewed the 10 most recent commits across `main`. Other issues investigated and ruled out:

| File | Finding | Decision |
|------|---------|----------|
| `BagStore.pin()` | `b.id != bag.id` — looks suspicious but `@Model` auto-generates `Identifiable` conformance using `persistentModelID`, so `.id` is correct | No change |
| `CameraPicker.swift` | `parent.dismiss()` before compression completes — `@Binding` holds a reference to the source `@State` storage which outlives the presented sheet, so the deferred write lands correctly | No change |
| Stores (`try? context.save()`) | Silent save failures — intentional pattern consistent across the codebase | No change |

## Test plan

- [ ] Open a brew with a non-empty grind setting — "Grind" row shows the value
- [ ] Open a brew with a nil or empty grind setting — "Grind" row shows "—"

https://claude.ai/code/session_01WZMB8vMb6gbVB9BBLDx6Qr

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZMB8vMb6gbVB9BBLDx6Qr)_