### PR TITLE
fix(pro/brews): StoreKit cache preserved on empty entitlements + prefill values survive method change

### DIFF
--- a/BeanBook/Features/Brews/NewBrewSheet.swift
+++ b/BeanBook/Features/Brews/NewBrewSheet.swift
@@ -621,6 +621,7 @@ struct NewBrewSheet: View {
     }
 
     private func applyMethodDefaultsIfFresh(_ method: BrewMethod) {
+        guard prefillSnapshot == nil else { return }
         dose = method.defaultDose
         yield = method.defaultYield
         brewTimeSeconds = method.defaultTimeSeconds

--- a/BeanBook/Pro/ProEntitlement.swift
+++ b/BeanBook/Pro/ProEntitlement.swift
@@ -116,14 +116,21 @@ final class ProEntitlement: ProEntitlementProviding {
 
     private func refreshEntitlements() async {
         var found = false
+        var didIterate = false
         for await result in Transaction.currentEntitlements {
+            didIterate = true
             if let txn = try? checkVerified(result),
                txn.productID == Self.productID,
                txn.revocationDate == nil {
                 found = true
             }
         }
-        setPro(found)
+        // Only update the cache when StoreKit returned at least one transaction.
+        // An empty sequence (e.g. fresh device before iCloud sync) is ambiguous —
+        // writing false here would incorrectly lock out users with a valid purchase.
+        if didIterate {
+            setPro(found)
+        }
     }
 
     private func handle(_ result: VerificationResult<Transaction>) async {


### PR DESCRIPTION
## High-confidence fixes (committed)

### 1. `ProEntitlement.refreshEntitlements()` — cache cleared when StoreKit returns nothing
`Transaction.currentEntitlements` yields zero items on a fresh device before iCloud sync completes. With `found` initialised to `false`, `setPro(false)` was called unconditionally, wiping the UserDefaults cache and temporarily locking out users with a valid purchase on first launch after reinstall.

**Fix:** track `didIterate` and only call `setPro` when the sequence returned at least one transaction. An empty sequence is treated as ambiguous — the existing cache survives.

**File:** `BeanBook/Pro/ProEntitlement.swift`

---

### 2. `NewBrewSheet.applyMethodDefaultsIfFresh()` — wipes prefill values on method change
When a brew is prefilled (`prefillSnapshot` is set), changing the brew method on Step 0 called `applyMethodDefaultsIfFresh` unconditionally, replacing the prefilled `dose`, `yield`, `brewTimeSeconds`, and `waterTempC` with the new method's defaults — silently discarding the values the user started from. `grindSetting` was already spared (not in that function), so the behaviour was also internally inconsistent.

**Fix:** `guard prefillSnapshot == nil else { return }` — defaults only apply on truly fresh forms where there is no pre-existing snapshot.

**File:** `BeanBook/Features/Brews/NewBrewSheet.swift`

---

## Lower-confidence issues flagged for review

These were identified during the audit but need product/design judgment before a code change is appropriate.

| # | File | Issue | Confidence |
|---|------|-------|------------|
| A | `Features/Shop/ShopView.swift` | Toast `Task` not cancelled on view disappear — add `.onDisappear { toastTask?.cancel() }` | MEDIUM |
| B | `Shared/SharedViews/TastingNotesEditor.swift` | Chip removal uses case-sensitive `==` while addition uses case-insensitive compare — use `caseInsensitiveCompare` in `removeAll` too | MEDIUM |
| C | `Core/Services/LocationService.swift` | `status` not set to `.requesting` before calling `requestLocation()` in `didChangeAuthorization` — any status-observing UI stalls in `.idle` | MEDIUM |
| D | `Features/Stats/StatsView.swift` | `brewsByID` dict rebuilt every SwiftUI body evaluation — move to `@State` updated via `onChange(of: brews)` | LOW |
| E | `BeanBook/BeanBookApp.swift` | Theme palette restored in `.task` (post-first-render) — consider restoring synchronously in `init()` to avoid one-frame flash | LOW |

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCoRcYfKDhaLfmXwdxT3mP)_