### PR TITLE
fix(stats): off-by-one in stats eyebrow day count

### DIFF
--- a/BeanBook/Features/Stats/StatsView.swift
+++ b/BeanBook/Features/Stats/StatsView.swift
@@ -257,7 +257,7 @@ struct StatsView: View {
         }
         let start = summary.windowStart.formatted(.dateTime.month(.abbreviated).day())
         let dayCount = Calendar.current.dateComponents([.day], from: summary.windowStart, to: summary.windowEnd).day ?? 29
-        return "\(dayCount + 1) days / since \(start)"
+        return "\(dayCount) days / since \(start)"
     }
 
     private var hasWorkingContent: Bool {


### PR DESCRIPTION
## What's in this PR

### ✅ Committed fix (HIGH confidence)

**`StatsView.swift` — `statsEyebrow` always shows N+1 days**

`dateComponents([.day], from: windowStart, to: windowEnd).day` already
returns the correct span. Adding `+ 1` inflated every label by one — a
30-day window read "30 days" instead of "29 days".

```swift
// before
return "\(dayCount + 1) days / since \(start)"

// after
return "\(dayCount) days / since \(start)"
```

---

## 🔍 Low-confidence issues — needs human review

These were identified during code review but not auto-fixed because they require design decisions or carry non-trivial refactoring risk.

### 1. `RecipesView.swift` — scratch `Brew` @Model used as prefill state

`RecipesView.list` creates an uninserted SwiftData `@Model` object and stores it in `@State private var prefillBrew: Brew?`. The concern: if SwiftData implicitly registers the orphaned object into the view's context (observed in some runtime configurations), it could be counted toward the free-tier quota or persisted on the next auto-save. `NewBrewSheet.applyPrefill` reads `source.bag` on the uninserted model; in practice this returns `nil` safely, but the contract is fragile.

**Suggested fix:** replace `prefillBrew: Brew?` with a plain value-type struct `BrewPrefillValues` carrying just the scalar fields, and pass that to `NewBrewSheet` instead.

### 2. `TodayView.swift` — hero copy always says "yesterday's was X"

`heroDescription(last:lastBag:)` uses the literal string `"yesterday's was \(qual)"` regardless of when the last brew was actually made. If the user's last brew was a week ago the copy is factually wrong.

**Suggested fix:**
```swift
let timeRef = Calendar.current.isDateInYesterday(last.createdAt) ? "yesterday's" : "last time's"
return "\(bag). Same dose, pulled \(time) — \(timeRef) was \(qual)."
```

### 3. `ProEntitlement.swift` — shallow recursion in `purchase()` on nil product

When `product` is nil, `purchase()` calls `loadProduct()` then calls `purchase()` recursively. Max depth is 2, so no stack overflow, but the state machine is confusing: `purchaseState` starts at `.idle`, enters `.loading` implicitly in `loadProduct`, then the recursive call sets `.purchasing`. The outer frame then returns, leaving the UI briefly in a stale intermediate state.

**Suggested fix:** flatten to a sequential guard without recursion:
```swift
func purchase() async {
    if product == nil { await loadProduct() }
    guard let product else { purchaseState = .failed("Product unavailable."); return }
    purchaseState = .purchasing
    // ...
}
```

### 4. `StatsView.swift` + `StatsSummary.swift` — activity strip "Today" label misaligned

`BrewActivityStrip` renders 30 data bars (`ForEach(days)`) followed by a hardcoded 6×12 accent stub. The "Today" text label (bottom-right) aligns visually with the accent stub, but `days.last` is already today's data bar. The accent stub reads as a separate day, making the strip appear 31 days wide and the "Today" label point to a non-data element.

**Suggested fix:** remove the hardcoded stub and instead style `days.last` with the accent fill to mark today directly.


---
_Generated by [Claude Code](https://claude.ai/code/session_014XLL8jxtXZDpqiWqtLyyrT)_