### PR TITLE
fix(stats/brews/recipes): 5 high-confidence bugs

### DIFF
--- a/BeanBook/Features/Brews/Components/BrewTimer.swift
+++ b/BeanBook/Features/Brews/Components/BrewTimer.swift
@@ -22,6 +22,7 @@ struct BrewTimer: View {
     @State private var isEditingTime = false
     @State private var editMinutes: Int = 0
     @State private var editSeconds: Int = 30
+    @State private var didHydrate = false
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
@@ -108,7 +109,11 @@ struct BrewTimer: View {
         .frame(maxWidth: .infinity)
         .sensoryFeedback(.success, trigger: hasFinished)
         .animation(.snappy(duration: 0.3), value: phase)
-        .onAppear { hydrateFromBinding() }
+        .onAppear {
+            guard !didHydrate else { return }
+            didHydrate = true
+            hydrateFromBinding()
+        }
         .onDisappear { commitElapsed() }
         .sheet(isPresented: $isEditingTime) {
             TimeEditSheet(
@@ -246,7 +251,7 @@ struct BrewTimer: View {
                 accumulated += Date().timeIntervalSince(start)
             }
             startDate = nil
-            seconds = max(lowerBound, Int(accumulated.rounded()))
+            seconds = Int(accumulated.rounded())
             phase = .paused
         case .paused:
             startDate = Date()
@@ -298,7 +303,7 @@ struct BrewTimer: View {
         // Save whichever is meaningful: elapsed time if they ran the timer,
         // otherwise the target they planned for.
         if accumulated > 0 {
-            seconds = max(lowerBound, Int(accumulated.rounded()))
+            seconds = Int(accumulated.rounded())
         } else {
             seconds = max(lowerBound, Int(target.rounded()))
         }

--- a/BeanBook/Features/Brews/NewBrewSheet.swift
+++ b/BeanBook/Features/Brews/NewBrewSheet.swift
@@ -19,6 +19,8 @@ struct NewBrewSheet: View {
     var initialBag: Bag? = nil
     /// Optional brew to pre-fill from (for "Brew this again" / Recipe launch).
     var prefill: Brew? = nil
+    /// Optional saved recipe to pre-fill from (for Recipe tab launch).
+    var prefillPreset: BrewPreset? = nil
 
     @State private var step: Int = 0
     @State private var method: BrewMethod = .espresso
@@ -571,6 +573,11 @@ struct NewBrewSheet: View {
         guard !didHydrate else { return }
         defer { didHydrate = true }
 
+        if let prefillPreset {
+            applyPrefill(from: prefillPreset, jumpToShot: true)
+            return
+        }
+
         if let prefill {
             applyPrefill(from: prefill, jumpToShot: true)
             return
@@ -616,6 +623,22 @@ struct NewBrewSheet: View {
             yield: source.yieldGrams,
             brewTimeSeconds: source.brewTimeSeconds,
             grindSetting: source.grindSetting ?? ""
+        )
+        if jumpToShot { step = 1 }
+    }
+
+    private func applyPrefill(from preset: BrewPreset, jumpToShot: Bool) {
+        method = preset.method
+        dose = preset.doseGrams
+        yield = preset.yieldGrams
+        brewTimeSeconds = preset.brewTimeSeconds
+        grindSetting = preset.grindSetting ?? ""
+        waterTempC = preset.waterTempC
+        prefillSnapshot = PrefillSnapshot(
+            dose: preset.doseGrams,
+            yield: preset.yieldGrams,
+            brewTimeSeconds: preset.brewTimeSeconds,
+            grindSetting: preset.grindSetting ?? ""
         )
         if jumpToShot { step = 1 }
     }

--- a/BeanBook/Features/Recipes/RecipesView.swift
+++ b/BeanBook/Features/Recipes/RecipesView.swift
@@ -6,7 +6,7 @@ struct RecipesView: View {
     @Environment(\.modelContext) private var context
     @Query(sort: \BrewPreset.createdAt, order: .reverse) private var presets: [BrewPreset]
 
-    @State private var prefillBrew: Brew?
+    @State private var prefillPreset: BrewPreset?
 
     var body: some View {
         ZStack {
@@ -27,8 +27,8 @@ struct RecipesView: View {
         }
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(.hidden, for: .navigationBar)
-        .sheet(item: $prefillBrew) { brew in
-            NewBrewSheet(prefill: brew)
+        .sheet(item: $prefillPreset) { preset in
+            NewBrewSheet(prefillPreset: preset)
         }
     }
 
@@ -49,15 +49,7 @@ struct RecipesView: View {
         VStack(spacing: 0) {
             ForEach(Array(presets.enumerated()), id: \.element.id) { _, preset in
                 Button {
-                    let scratch = Brew(
-                        method: preset.method,
-                        doseGrams: preset.doseGrams,
-                        yieldGrams: preset.yieldGrams,
-                        brewTimeSeconds: preset.brewTimeSeconds,
-                        grindSetting: preset.grindSetting,
-                        waterTempC: preset.waterTempC
-                    )
-                    prefillBrew = scratch
+                    prefillPreset = preset
                 } label: {
                     PresetRow(preset: preset)
                 }

--- a/BeanBook/Features/Stats/StatsSummary.swift
+++ b/BeanBook/Features/Stats/StatsSummary.swift
@@ -176,9 +176,7 @@ extension StatsSummary {
     private static func dialInRows(from brews: [Brew], bag: Bag?) -> [DialInRow] {
         guard let bag else { return [] }
         return brews
-            .filter { brew in
-                brew.method == .espresso && brew.bag?.persistentModelID == bag.persistentModelID
-            }
+            .filter { $0.bag?.persistentModelID == bag.persistentModelID }
             .prefix(5)
             .map(DialInRow.init)
     }

--- a/BeanBook/Features/Stats/StatsView.swift
+++ b/BeanBook/Features/Stats/StatsView.swift
@@ -368,16 +368,13 @@ private struct BrewActivityStrip: View {
 
             HStack(alignment: .bottom, spacing: 4) {
                 ForEach(days) { day in
+                    let isToday = day.id == days.last?.id
                     RoundedRectangle(cornerRadius: 1.5)
-                        .fill(day.count > 0 ? Theme.ink.opacity(0.82) : Theme.rule)
+                        .fill(isToday ? Theme.accent : (day.count > 0 ? Theme.ink.opacity(0.82) : Theme.rule))
                         .frame(maxWidth: .infinity)
                         .frame(height: height(for: day.count))
                         .accessibilityLabel("\(day.count) brews")
                 }
-                RoundedRectangle(cornerRadius: 1.5)
-                    .fill(Theme.accent)
-                    .frame(width: 6, height: 12)
-                    .accessibilityHidden(true)
             }
             .frame(height: 44, alignment: .bottom)
 


### PR DESCRIPTION
## Summary

Five high-confidence bugs found during automated code review of the most recent commits.

- **StatsSummary.dialInRows**: Hardcoded `.espresso` filter meant the Dial-in section was always empty for pour-over, AeroPress, and every other non-espresso method. Removed the method guard — the section now shows the 5 most recent brews for whatever bag is selected as the dial-in bag.
- **StatsView.BrewActivityStrip**: An extra accent bar was appended unconditionally after the 30-day `ForEach`, making the strip show 31 bars while the label said "30 days". Removed the extra bar and color today's data bar with `Theme.accent` instead so the strip is accurate and today is still visually distinct.
- **BrewTimer.toggle (pause path)**: Elapsed time was clamped to `max(lowerBound, …)` (5 s minimum) before being written back to the `seconds` binding. A brew paused at 2 s would save as 5 s. Removed the clamp — the lower bound only applies to the *target* duration.
- **BrewTimer.commitElapsed**: Same `max(lowerBound, …)` clamp on the elapsed write-back. Fixed the same way.
- **BrewTimer.hydrateFromBinding / onAppear**: `hydrateFromBinding()` was called on every `onAppear`, including re-fires after a child sheet (e.g. paywall) dismisses. This could reset `target` mid-run and corrupt elapsed time. Added a `didHydrate` guard so it runs exactly once.
- **RecipesView + NewBrewSheet**: Tapping a recipe created an unmanaged SwiftData `@Model` scratch `Brew` and passed it as `prefill:` — undefined behavior since the object is never inserted into a `ModelContext`. Replaced with a new `prefillPreset: BrewPreset?` parameter on `NewBrewSheet` and a matching `applyPrefill(from:BrewPreset:)` overload. `RecipesView` now passes the `BrewPreset` directly without creating any scratch objects.

## Low-confidence issues (not included — need human review)

- `StatsView.statsEyebrow` day-count: re-derives the 30-day count from `dateComponents` with a `?? 29` fallback; could show "29 days" near day boundaries. Low risk / cosmetic.
- `NewBrewSheet.task(id: showSaved)`: `try? Task.sleep` silences `CancellationError` making the `guard !Task.isCancelled` dead code. Current behavior is accidentally correct but fragile.
- `BagDetailView`: `bag.brews` traversed 3× per render — lazy fault on main thread, performance at scale.
- `CameraPicker`: `parent.dismiss()` fires before async image compression completes; safe in practice but ordering is subtle.

## Test plan

- [ ] Log a pour-over or AeroPress brew with a bag → confirm Dial-in section appears in Stats
- [ ] Open Stats → Activity strip shows exactly 30 bars; today's bar is accent-colored
- [ ] Start timer, pause immediately (< 5 s) → confirm saved brew time is the actual elapsed seconds, not 5 s
- [ ] Start timer in NewBrewSheet, open/close paywall sheet → confirm timer target and elapsed are unchanged on return
- [ ] Tap a recipe in the Recipes tab → NewBrewSheet opens on Shot step with values pre-filled; no crash

https://claude.ai/code/session_018YBXGaeY2LpGwhbb352Ksr

---
_Generated by [Claude Code](https://claude.ai/code/session_018YBXGaeY2LpGwhbb352Ksr)_