### PR TITLE
fix: reliable bag-deletion onChange, empty-state label, linearize purchase() retry

### DIFF
--- a/BeanBook/Features/Brews/BrewListView.swift
+++ b/BeanBook/Features/Brews/BrewListView.swift
@@ -66,6 +66,13 @@ struct BrewListView: View {
         return result
     }
 
+    /// Value-typed set of PersistentIdentifiers for reliable onChange equality.
+    /// SwiftData model arrays use object-pointer equality, which can miss deletions;
+    /// PersistentIdentifier is Equatable by value and always reflects the live store state.
+    private var bagsInBrewsIDs: Set<PersistentIdentifier> {
+        Set(brews.compactMap { $0.bag?.persistentModelID })
+    }
+
     private var hasActiveFilter: Bool { methodFilter != nil || bagFilterID != nil || isSearching }
     private var showsFilters: Bool { brews.count >= 5 }
 
@@ -146,8 +153,8 @@ struct BrewListView: View {
                 bagFilterID = nil
             }
         }
-        .onChange(of: bagsInBrews) { _, newBags in
-            if let bagFilterID, !newBags.contains(where: { $0.persistentModelID == bagFilterID }) {
+        .onChange(of: bagsInBrewsIDs) { _, newIDs in
+            if let bagFilterID, !newIDs.contains(bagFilterID) {
                 self.bagFilterID = nil
             }
         }
@@ -290,7 +297,7 @@ struct BrewListView: View {
                 .font(.system(size: 22, weight: .medium, design: .serif))
                 .tracking(-0.4)
                 .foregroundStyle(Theme.ink)
-            Button(isSearching && (methodFilter == nil && bagFilterID == nil) ? "Clear search" : "Clear filters") {
+            Button(isSearching ? "Clear search" : "Clear filters") {
                 methodFilter = nil
                 bagFilterID = nil
                 searchText = ""

--- a/BeanBook/Pro/ProEntitlement.swift
+++ b/BeanBook/Pro/ProEntitlement.swift
@@ -59,13 +59,12 @@ final class ProEntitlement: ProEntitlementProviding {
     }
 
     func purchase() async {
-        guard let product else {
+        // Load the product on demand if it wasn't fetched at startup (e.g. offline launch).
+        if product == nil {
             await loadProduct()
-            guard product != nil else {
-                purchaseState = .failed("Product unavailable.")
-                return
-            }
-            await purchase()
+        }
+        guard let product else {
+            purchaseState = .failed("Product unavailable.")
             return
         }
         purchaseState = .purchasing


### PR DESCRIPTION
## Summary

Automated review of recent commits (through `db92193`). Two commits: auto-validated fixes land first, medium-confidence fixes land second with a `needs-review` note.

---

## ✅ Commit 1 — Auto-validated (HIGH confidence, safe to merge)

### `BrewListView` — reliable bag-deletion detection via `Set<PersistentIdentifier>`
**Bug:** `onChange(of: bagsInBrews)` observed a `[Bag]` array. SwiftData `@Model` arrays default to object-pointer equality, which can miss deletions if SwiftUI's change-detection evaluates the array before the model graph fully updates. `PersistentIdentifier` is value-typed with correct `Equatable` semantics and always reflects live store state.

**Fix:** Add `bagsInBrewsIDs: Set<PersistentIdentifier>` (one-liner over the same `brews` query) and switch the `onChange` to observe it. The existing `bagsInBrews: [Bag]` property is kept unchanged for the filter-chip UI.

---

### `BrewListView.filteredEmptyState` — simplified button label
**Bug:** The button label condition `isSearching && (methodFilter == nil && bagFilterID == nil)` is always `true` when `isSearching` is true. The `onChange(of: isSearching)` handler already clears both chip filters before the empty state renders, so the `methodFilter == nil && bagFilterID == nil` clause is always satisfied — the "Clear filters" branch was unreachable while searching.

**Fix:** Replace with `isSearching ? "Clear search" : "Clear filters"`.

---

## ⚠️ Commit 2 — Needs review (MEDIUM confidence)

### `ProEntitlement.purchase()` — linearize recursive retry
**Bug:** The original implementation called `await purchase()` recursively after a successful `loadProduct()` retry. While bounded to one level in the happy path, a concurrent state mutation between the two `await` calls (e.g. `product` nilled out by another path) could trigger a second recursive call. The pattern is fragile and confusing for future maintainers.

**Fix:** Refactor to a linear flow — call `loadProduct()` once if `product == nil`, then re-check with `guard let product` before proceeding. No behaviour change in the normal case; the failure path is now a straight-line guard.

**Please verify:** The paywall purchase flow still works end-to-end in the sandbox environment (product loads on first tap, loads-then-purchases on a cold launch where `start()` didn't populate the product yet).

---

## Remaining issues found (not fixed — higher complexity / needs design input)

| # | File | Issue |
|---|------|-------|
| B-4 | `NewBrewSheet` | Prefill bag assigned from `brewStore.mostRecent()` context may be a different object instance than the one in `@Query bags`, causing the bag picker to show the wrong row as selected. Fix: resolve prefill bag against `bags.first { $0.persistentModelID == ... }` after `applyPrefill`. |
| B-7 | `NewBagSheet` | `Task.detached` compresses images on a background thread using UIKit (`UIImage.jpegData()`). UIImage is documented as read-only safe on background threads but compression/resize operations are not guaranteed thread-safe. Consider auditing `ImageCompressor` or removing the detach. |
| B-8 | `NewBrewSheet` | When `saveAsPreset` throws `QuotaExceededError`, the paywall is shown but `showSaved` overlay is never set — the user doesn't know the brew itself was already saved and may try to save again. Show `showSaved = true` before returning. |
| B-12 | `BagDetailView` | `bag.brews` accessed on a bag deleted from a parent list view will fault on a tombstoned SwiftData object. Add `.onChange(of: bag.isDeleted) { if $0 { dismiss() } }`. |

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvXwpNKecryAVRXEDhyVNV)_