### PR TITLE
fix(brews/today): bag name fallbacks — BrewListRow displayTitle + TodayView edge cases

### DIFF
--- a/BeanBook/Features/Brews/BrewListView.swift
+++ b/BeanBook/Features/Brews/BrewListView.swift
@@ -387,7 +387,7 @@ private struct BrewListRow: View {
     }
 
     private var detail: String {
-        let bag = brew.bag?.brand ?? "—"
+        let bag = brew.bag?.displayTitle ?? "—"
         let date = brew.createdAt.formatted(.relative(presentation: .numeric))
         return "\(bag) · \(date)"
     }

--- a/BeanBook/Features/Today/TodayView.swift
+++ b/BeanBook/Features/Today/TodayView.swift
@@ -240,8 +240,9 @@ private struct TodayBrewRow: View {
 
     private var rowDetail: String {
         let when = brew.createdAt.formatted(.relative(presentation: .numeric))
-        if let bag = brew.bag?.brand, !bag.isEmpty {
-            return "\(bag) · \(when)"
+        if let bag = brew.bag {
+            let label = bag.brand.isEmpty ? bag.name : bag.brand
+            if !label.isEmpty { return "\(label) · \(when)" }
         }
         return when
     }
@@ -253,7 +254,7 @@ private struct TodayBagRow: View {
     var body: some View {
         HStack {
             VStack(alignment: .leading, spacing: 3) {
-                Text(bag.name.isEmpty ? bag.brand : bag.name)
+                Text(bag.name.isEmpty ? (bag.brand.isEmpty ? "Untitled bag" : bag.brand) : bag.name)
                     .font(.system(size: 19, weight: .medium, design: .serif))
                     .tracking(-0.3)
                     .foregroundStyle(Theme.ink)


### PR DESCRIPTION
## Summary

Caught while reviewing commits since #21. PR #21 introduced `Bag.displayTitle` and used it in `BrewDetailView`, but two files still access `bag.brand` directly and produce wrong output when `brand` is empty but `name` is set.

### HIGH confidence — auto-pushed

**`BrewListView` — `BrewListRow.detail`**

`brew.bag?.brand ?? "—"` produces ` · 2 hours ago` (blank bag label + dangling separator) when a bag has an empty `brand` but a populated `name`. The `?? "—"` fallback only fires when `brew.bag` is `nil` — it doesn't guard an empty string.

Fix: switch to `brew.bag?.displayTitle ?? "—"`, consistent with the approach taken for `BrewDetailView` in #21.

### MEDIUM confidence — included for review

**`TodayView` — `TodayBrewRow.rowDetail`**

Used `brew.bag?.brand` with a `!isEmpty` guard, so a brew linked to a name-only bag showed just the relative date with no bag context at all (e.g., `"2 hours ago"` instead of `"Ethiopian Yirgacheffe · 2 hours ago"`).

Fix: check `name` when `brand` is empty, matching the intent.

**`TodayView` — `TodayBagRow` title**

`bag.name.isEmpty ? bag.brand : bag.name` renders an empty `Text` when both `name` and `brand` are unset. Adds `"Untitled bag"` as the final fallback, matching `Bag.displayTitle`.

## Test plan

- [ ] Log a brew linked to a bag that has **only a name** (no brand). Confirm the brew list row shows `BagName · 2 hours ago` instead of ` · 2 hours ago`
- [ ] Confirm the Today screen brew row for the same bag shows `BagName · 2 hours ago` (previously showed just `2 hours ago`)
- [ ] Log a brew with no bag — confirm row shows `— · 2 hours ago`
- [ ] Log a brew with a bag that has both brand and name — confirm row shows `Brand · 2 hours ago` (unchanged behaviour)
- [ ] Add a bag with neither name nor brand — confirm Today beans row shows `Untitled bag` instead of blank text

https://claude.ai/code/session_011nxuqPvQNEpqkjqXstEr81

---
_Generated by [Claude Code](https://claude.ai/code/session_011nxuqPvQNEpqkjqXstEr81)_