### PR TITLE
fix(stores): rollback insert on context.save() failure

### DIFF
--- a/BeanBook/Core/Stores/BagStore.swift
+++ b/BeanBook/Core/Stores/BagStore.swift
@@ -43,7 +43,12 @@ final class BagStore {
             notes: notes
         )
         context.insert(bag)
-        try? context.save()
+        do {
+            try context.save()
+        } catch {
+            context.delete(bag)
+            throw error
+        }
         return bag
     }
 

--- a/BeanBook/Core/Stores/BrewPresetStore.swift
+++ b/BeanBook/Core/Stores/BrewPresetStore.swift
@@ -39,7 +39,12 @@ final class BrewPresetStore {
             waterTempC: waterTempC
         )
         context.insert(preset)
-        try? context.save()
+        do {
+            try context.save()
+        } catch {
+            context.delete(preset)
+            throw error
+        }
         return preset
     }
 }

--- a/BeanBook/Core/Stores/BrewStore.swift
+++ b/BeanBook/Core/Stores/BrewStore.swift
@@ -43,7 +43,12 @@ final class BrewStore {
             bag: bag
         )
         context.insert(brew)
-        try? context.save()
+        do {
+            try context.save()
+        } catch {
+            context.delete(brew)
+            throw error
+        }
         return brew
     }
 


### PR DESCRIPTION
## Summary

- **BagStore.create()**, **BrewStore.create()**, **BrewPresetStore.create()**: replace `try? context.save()` with a proper insert-rollback pattern so a save failure doesn't leave a phantom record in the SwiftData context.

## Why this matters

All three `create()` functions are already declared `throws`, but their `context.save()` calls used `try?` — silently swallowing any persistence error. When save fails, the object was inserted into the in-memory `ModelContext` (and therefore appeared immediately in `@Query`-driven views) while never making it to disk. The result is a record the user can see and interact with that vanishes the next time the app is launched fresh.

The fix makes the failure mode explicit: on save failure, the inserted object is deleted from the context (keeping in-memory state clean) and the error is re-thrown to the caller, which already has a `catch {}` handler.

```swift
// Before
context.insert(bag)
try? context.save()
return bag

// After
context.insert(bag)
do {
    try context.save()
} catch {
    context.delete(bag)
    throw error
}
return bag
```

`BagStore.pin()` intentionally keeps `try? context.save()` — it toggles an attribute on an already-persisted record (no new objects created) so autosave is an acceptable fallback.

## Lower-confidence issues found during review (not in this PR)

These were identified but not fixed due to lower certainty or requiring larger changes:

1. **`BagStore.pin()` — potential dual-pinned bags on fetch failure (LOW)**  
   If `try? context.fetch(...)` throws and returns `[]`, the loop that unpins other bags is skipped, but the new bag is still pinned — violating the single-pin invariant. SwiftData fetch failures in this scenario are extremely rare (corrupt store only), so this is a known edge case.

2. **`NewBrewSheet.save()` — misleading comment on preset-save catch block (LOW)**  
   The generic `catch` in the `brewPresetStore.create()` call has the comment `// Same fall-through as above.` — but "above" (`brewStore.create()`) explicitly `return`s. The preset catch deliberately does *not* return (because the brew itself succeeded) but the comment implies otherwise. Suggest either removing the comment or replacing it with: `// Brew saved successfully; preset failure is non-fatal.`

## Test plan

- [ ] Create a bag normally — should succeed and persist across app restart
- [ ] Create a brew normally — should succeed and persist across app restart
- [ ] Save a brew as a recipe — should succeed and persist across app restart
- [ ] Verify no regressions in bag/brew/recipe list views after create operations

https://claude.ai/code/session_01VLAcDEQ86Ps9iCZStmyQq3

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLAcDEQ86Ps9iCZStmyQq3)_