### PR TITLE
fix(brews/recipes): eliminate force-unwrap and unsafe uninserted model as sheet item

### DIFF
--- a/BeanBook/Features/Brews/BrewDetailView.swift
+++ b/BeanBook/Features/Brews/BrewDetailView.swift
@@ -137,7 +137,7 @@ struct BrewDetailView: View {
             if let temp = brew.waterTempC {
                 RuleRow("Water", value: "\(Int(temp))°C")
             }
-            RuleRow("Grind", value: brew.grindSetting?.isEmpty == false ? brew.grindSetting! : "—")
+            RuleRow("Grind", value: brew.grindSetting.flatMap { $0.isEmpty ? nil : $0 } ?? "—")
         }
         .padding(.horizontal, 28)
         .padding(.top, Theme.p(36))

--- a/BeanBook/Features/Brews/NewBrewSheet.swift
+++ b/BeanBook/Features/Brews/NewBrewSheet.swift
@@ -17,8 +17,10 @@ struct NewBrewSheet: View {
 
     /// Optional bag to pre-link.
     var initialBag: Bag? = nil
-    /// Optional brew to pre-fill from (for "Brew this again" / Recipe launch).
+    /// Optional brew to pre-fill from (for “Brew this again” / hot-start from recent shots).
     var prefill: Brew? = nil
+    /// Optional preset to pre-fill from (for recipe launch via RecipesView).
+    var prefillPreset: BrewPreset? = nil
 
     @State private var step: Int = 0
     @State private var method: BrewMethod = .espresso
@@ -571,6 +573,11 @@ struct NewBrewSheet: View {
         guard !didHydrate else { return }
         defer { didHydrate = true }
 
+        if let prefillPreset {
+            applyPrefill(from: prefillPreset)
+            return
+        }
+
         if let prefill {
             applyPrefill(from: prefill, jumpToShot: true)
             return
@@ -601,6 +608,23 @@ struct NewBrewSheet: View {
         if let pinned = bagStore.pinnedBag {
             bag = pinned
         }
+    }
+
+    private func applyPrefill(from preset: BrewPreset) {
+        method = preset.method
+        dose = preset.doseGrams
+        yield = preset.yieldGrams
+        brewTimeSeconds = preset.brewTimeSeconds
+        grindSetting = preset.grindSetting ?? ""
+        waterTempC = preset.waterTempC
+        bag = bagStore.pinnedBag
+        prefillSnapshot = PrefillSnapshot(
+            dose: preset.doseGrams,
+            yield: preset.yieldGrams,
+            brewTimeSeconds: preset.brewTimeSeconds,
+            grindSetting: preset.grindSetting ?? ""
+        )
+        step = 1
     }
 
     private func applyPrefill(from source: Brew, jumpToShot: Bool) {

--- a/BeanBook/Features/Recipes/RecipesView.swift
+++ b/BeanBook/Features/Recipes/RecipesView.swift
@@ -6,7 +6,7 @@ struct RecipesView: View {
     @Environment(\.modelContext) private var context
     @Query(sort: \BrewPreset.createdAt, order: .reverse) private var presets: [BrewPreset]
 
-    @State private var prefillBrew: Brew?
+    @State private var selectedPreset: BrewPreset?
 
     var body: some View {
         ZStack {
@@ -27,8 +27,8 @@ struct RecipesView: View {
         }
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(.hidden, for: .navigationBar)
-        .sheet(item: $prefillBrew) { brew in
-            NewBrewSheet(prefill: brew)
+        .sheet(item: $selectedPreset) { preset in
+            NewBrewSheet(prefillPreset: preset)
         }
     }
 
@@ -49,15 +49,7 @@ struct RecipesView: View {
         VStack(spacing: 0) {
             ForEach(Array(presets.enumerated()), id: \.element.id) { _, preset in
                 Button {
-                    let scratch = Brew(
-                        method: preset.method,
-                        doseGrams: preset.doseGrams,
-                        yieldGrams: preset.yieldGrams,
-                        brewTimeSeconds: preset.brewTimeSeconds,
-                        grindSetting: preset.grindSetting,
-                        waterTempC: preset.waterTempC
-                    )
-                    prefillBrew = scratch
+                    selectedPreset = preset
                 } label: {
                     PresetRow(preset: preset)
                 }


### PR DESCRIPTION
## Summary

Two bug fixes found during commit review. One is a straightforward cleanup, the other is a design correction that warrants review.

---

### ✅ High confidence — auto-pushed (ready to merge)

**`BrewDetailView.swift`: Eliminate unnecessary force-unwrap in grind setting display**

The `params` computed property used `brew.grindSetting?.isEmpty == false ? brew.grindSetting! : "—"` — a force-unwrap that is safe only because of the preceding nil/empty check, but is still a crash risk if the condition is ever refactored. Replaced with the idiomatic `flatMap` form:

```swift
// Before
RuleRow("Grind", value: brew.grindSetting?.isEmpty == false ? brew.grindSetting! : "—")

// After
RuleRow("Grind", value: brew.grindSetting.flatMap { $0.isEmpty ? nil : $0 } ?? "—")
```

No behaviour change; eliminates the force-unwrap entirely.

---

### ⚠️ Medium confidence — needs review

**`RecipesView.swift` + `NewBrewSheet.swift`: Replace uninserted `Brew` model with `BrewPreset` as sheet item**

`RecipesView` was constructing a scratch `Brew` object (not inserted into any `ModelContext`) and using it as the `.sheet(item:)` binding. Passing an uninserted `@Model` across view boundaries is fragile — SwiftData can fail to resolve its `PersistentIdentifier`, causing the sheet not to open or crashing on access.

**Fix:** Pass the `BrewPreset` directly (it is already a managed, inserted model and conforms to `Identifiable`), then apply its values inside `NewBrewSheet` via a new `applyPrefill(from: BrewPreset)` path.

Changes:
- `RecipesView`: `@State private var prefillBrew: Brew?` → `@State private var selectedPreset: BrewPreset?`; sheet now passes the preset rather than a scratch brew
- `NewBrewSheet`: Added `var prefillPreset: BrewPreset? = nil` parameter and `applyPrefill(from: BrewPreset)` method; `hydrate()` checks `prefillPreset` before the existing `prefill: Brew?` path
- Since `BrewPreset` has no `bag` field, `applyPrefill(from:)` falls back to `bagStore.pinnedBag` (same behaviour as before)

**Please verify:** the `NewBrewSheet` hydration flow and that the pinned-bag fallback is the right UX choice when launching from a preset.

## Test plan
- [ ] Open a brew preset in RecipesView — confirm the new brew sheet opens pre-filled with the preset's values
- [ ] Confirm the grind setting row in BrewDetailView still displays "—" when grind is nil or empty, and shows the value otherwise
- [ ] Confirm no crashes when dismissing and re-opening the new brew sheet from a preset

---
_Generated by [Claude Code](https://claude.ai/code/session_017rTsXNa6cBchEuJUB7CKKp)_