### PR TITLE
fix(brew-detail): remove force-unwrap on grindSetting

### DIFF
--- a/BeanBook/Features/Brews/BrewDetailView.swift
+++ b/BeanBook/Features/Brews/BrewDetailView.swift
@@ -137,7 +137,7 @@ struct BrewDetailView: View {
             if let temp = brew.waterTempC {
                 RuleRow("Water", value: "\(Int(temp))°C")
             }
-            RuleRow("Grind", value: brew.grindSetting?.isEmpty == false ? brew.grindSetting! : "—")
+            RuleRow("Grind", value: brew.grindSetting ?? "—")
         }
         .padding(.horizontal, 28)
         .padding(.top, Theme.p(36))


### PR DESCRIPTION
## Summary

- Replace `brew.grindSetting?.isEmpty == false ? brew.grindSetting! : "—"` with `brew.grindSetting ?? "—"` in `BrewDetailView.params`

## Why

The force-unwrap was safe by current invariant — `NewBrewSheet.save()` converts empty grind strings to `nil` before writing to SwiftData, so `grindSetting` is always either `nil` or a non-empty `String` at the model layer. The `?.isEmpty == false` check was therefore redundant, and the `!` was unnecessary.

However the pattern is fragile: any direct model mutation, a future migration, or a test fixture that stores `""` instead of `nil` would crash at this line. `?? "—"` is strictly equivalent under the current invariant, removes the crash vector, and reads more clearly.

## Review notes (other findings — not changed)

During the same review pass, two other items were flagged by automated analysis but confirmed to be non-issues:

**Wheel-check `GPSLapTimerService` — "race condition"**: The sub-agent flagged concurrent access to `breadcrumbs` between `consumerTask` and `checkLapCrossing`. This is a false positive — both tasks inherit `@MainActor` isolation from `startRecording`, so Swift's actor serialization prevents any true interleaving. No fix needed.

**BeanBook `grindCaption` in `NewBrewSheet`**: The condition `!s.grindSetting.isEmpty` was flagged as inconsistent. It's intentional: showing `"was "` (empty) when the prefill had no grind setting would be meaningless noise. Confirmed by tracing the condition — the "was X" caption does correctly appear when the user clears a previously-set grind value.

https://claude.ai/code/session_014mZeL7JXhdmYJHErg2RNw2

---
_Generated by [Claude Code](https://claude.ai/code/session_014mZeL7JXhdmYJHErg2RNw2)_