### PR TITLE
Fix hydrate() ignoring autoPrefillFromLast when initialBag is set

### DIFF
--- a/BeanBook/Features/Brews/NewBrewSheet.swift
+++ b/BeanBook/Features/Brews/NewBrewSheet.swift
@@ -590,8 +590,23 @@ struct NewBrewSheet: View {
 
         if let initialBag {
             bag = initialBag
-            method = BrewMethod(rawValue: defaultBrewMethodRaw) ?? .espresso
-            applyMethodDefaultsIfFresh(method)
+            if autoPrefillFromLast, let recent = brewStore.mostRecent() {
+                method = recent.method
+                dose = recent.doseGrams
+                yield = recent.yieldGrams
+                brewTimeSeconds = recent.brewTimeSeconds
+                grindSetting = recent.grindSetting ?? ""
+                waterTempC = recent.waterTempC
+                prefillSnapshot = PrefillSnapshot(
+                    dose: recent.doseGrams,
+                    yield: recent.yieldGrams,
+                    brewTimeSeconds: recent.brewTimeSeconds,
+                    grindSetting: recent.grindSetting ?? ""
+                )
+            } else {
+                method = BrewMethod(rawValue: defaultBrewMethodRaw) ?? .espresso
+                applyMethodDefaultsIfFresh(method)
+            }
             return
         }
 


### PR DESCRIPTION
## Summary

- **`NewBrewSheet.hydrate()` ignores `autoPrefillFromLast` when `initialBag` is set**: When the sheet is opened with a specific bag (e.g. from a bag detail view), the `if let initialBag` branch unconditionally applied bare method defaults — `autoPrefillFromLast` was completely ignored. This means users who have the preference enabled would see stale defaults (dose, yield, time, grind) instead of their last brew's values whenever they start a brew from a bag context. Fixed by checking `autoPrefillFromLast` inside the `initialBag` branch: if enabled and a recent brew exists, shot params are applied from that brew while the explicitly-passed bag is still used; otherwise method defaults are applied as before.

> **Note:** This PR targets `claude/brave-ritchie-ZVOiq` (the high-confidence fixes branch) rather than `main` to avoid diff noise from the `prefillPreset` changes in that branch.

## Test plan

- [ ] Open a new brew from a bag detail view with `autoPrefillFromLast` **ON** and at least one prior brew — verify dose/yield/time/grind prefill from the last brew, and the correct bag is pre-selected
- [ ] Open a new brew from a bag detail view with `autoPrefillFromLast` **OFF** — verify method defaults are applied
- [ ] Open a new brew from the "+" button (cold start) — verify existing behavior unchanged
- [ ] Open a new brew from a recipe preset — verify existing behavior unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01Un88FhXgHzdM1XVxZtW8pz)_