### PR TITLE
fix(brews): use bag.displayTitle in BrewListRow to avoid blank brand

### DIFF
--- a/BeanBook/Features/Brews/BrewListView.swift
+++ b/BeanBook/Features/Brews/BrewListView.swift
@@ -387,7 +387,7 @@ private struct BrewListRow: View {
     }
 
     private var detail: String {
-        let bag = brew.bag?.brand ?? "—"
+        let bag = brew.bag?.displayTitle ?? "—"
         let date = brew.createdAt.formatted(.relative(presentation: .numeric))
         return "\(bag) · \(date)"
     }


### PR DESCRIPTION
## Bug

`BrewListRow.detail` used `brew.bag?.brand ?? "—"` to show the bag name in the list subtitle. `Bag.brand` is a non-optional `String` that defaults to `""`, so if a user's bag has no brand set the optional-chaining returns `Optional("")` — not `nil` — and the `?? "—"` fallback never fires. The row renders as `" · 2 days ago"` (leading space, no bag identifier).

This is the same class of issue that was fixed in `BrewDetailView` in #21 by switching to `bag.displayTitle`.

## Fix

Replace `brew.bag?.brand ?? "—"` with `brew.bag?.displayTitle ?? "—"` in `BrewListRow.detail`.

`displayTitle` already handles all three cases:
- brand + name → `"Brand — Name"`
- brand only → `"Brand"`
- name only → `"Name"`
- neither → `"Untitled bag"`

## Confidence

**High** — same pattern, same model, mirrors the already-merged fix in `BrewDetailView`. One-line change with no logic impact.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RUTQYYrpfKDWmPJcdangsF)_