### PR TITLE
fix(pro): linearize purchase() retry instead of recursive call

### DIFF
--- a/BeanBook/Pro/ProEntitlement.swift
+++ b/BeanBook/Pro/ProEntitlement.swift
@@ -59,13 +59,12 @@ final class ProEntitlement: ProEntitlementProviding {
     }
 
     func purchase() async {
-        guard let product else {
+        // Load the product on demand if it wasn't fetched at startup (e.g. offline launch).
+        if product == nil {
             await loadProduct()
-            guard product != nil else {
-                purchaseState = .failed("Product unavailable.")
-                return
-            }
-            await purchase()
+        }
+        guard let product else {
+            purchaseState = .failed("Product unavailable.")
             return
         }
         purchaseState = .purchasing


### PR DESCRIPTION
## Summary

The original `purchase()` recursively called itself after `loadProduct()` to retry with the now-loaded product:

```swift
func purchase() async {
    guard let product else {
        await loadProduct()
        guard product != nil else {
            purchaseState = .failed("Product unavailable.")
            return
        }
        await purchase()   // recursive
        return
    }
    purchaseState = .purchasing
    ...
}
```

In practice this terminates (the second invocation hits the captured-product happy path), but it's fragile and harder to reason about than a flat shape. Restructured to "load if needed, then guard, then proceed" — same behavior, no recursion.

## Provenance

Extracted from [#28](https://github.com/m-lair/BeanBook/pull/28). The BrewListView changes in #28 (`bagsInBrewsIDs` Set + button label simplification) are duplicates of [#29](https://github.com/m-lair/BeanBook/pull/29), which is already in main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)