### PR TITLE
fix(stats): use bag.displayTitle in BrewRow detail instead of brand

### DIFF
--- a/BeanBook/Features/Stats/StatsSummary.swift
+++ b/BeanBook/Features/Stats/StatsSummary.swift
@@ -236,8 +236,8 @@ extension StatsSummary.BrewRow {
 
     private static func detail(for brew: Brew) -> String {
         let date = brew.createdAt.formatted(date: .abbreviated, time: .omitted)
-        if let bag = brew.bag?.brand, !bag.isEmpty {
-            return "\(bag) / \(date)"
+        if let bag = brew.bag {
+            return "\(bag.displayTitle) / \(date)"
         }
         return date
     }


### PR DESCRIPTION
## Summary

**High-confidence bug fix** — identical pattern already corrected in three other places.

- `StatsSummary.BrewRow.detail(for:)` used `brew.bag?.brand` with an `isEmpty` guard. Because `Bag.brand` is a non-optional `String = ""`, the optional binding only fails when the bag itself is nil — not when the bag exists but has only a `name` set. Users whose bags have only a `name` (no `brand`) see Stats rows with just the date and no bag label at all, e.g. `"May 15"` instead of `"Ethiopia Yirgacheffe / May 15"`.
- Fix: replace with `brew.bag?.displayTitle`, which falls through `brand → name → "Untitled bag"`.

## Prior art

The same empty-brand pattern was found and fixed in:
| Commit | Location |
|--------|----------|
| #21 | `BrewDetailView` |
| #30 | `TodayBrewRow` + `TodayBagRow` |
| #37 / #29 | `BrewListRow` |

`StatsSummary.BrewRow` was the only remaining callsite.

## Test plan
- [ ] Add a bag with only a **name** field (brand left blank) and log a brew against it
- [ ] Open Stats → What's working / Logged so far rows should show the bag name
- [ ] Add a bag with both brand and name — row should show `"Brand — Name / date"`
- [ ] Add a bag with only a brand — row should show `"Brand / date"`
- [ ] Bag-less brew — row should show just the date (no separator)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8HRChZktZK92Gzbj98Y2W)_