### PR TITLE
fix(brews): prevent duplicate brew on preset-quota paywall + apply pinned bag on recipe launch

### DIFF
--- a/BeanBook/Features/Brews/NewBrewSheet.swift
+++ b/BeanBook/Features/Brews/NewBrewSheet.swift
@@ -44,6 +44,7 @@ struct NewBrewSheet: View {
     @State private var showSaved = false
     @State private var savedScale: CGFloat = 0
     @State private var didHydrate = false
+    @State private var brewCommitted = false
 
     @AppStorage("timerCountsDown") private var timerCountsDown = true
     @AppStorage("defaultBrewMethod") private var defaultBrewMethodRaw: String = BrewMethod.espresso.rawValue
@@ -521,6 +522,7 @@ struct NewBrewSheet: View {
     }
 
     private func save() {
+        guard !brewCommitted else { return }
         let resolvedGrind = grindSetting.isEmpty ? nil : grindSetting
         let resolvedNotes = notes.isEmpty ? nil : notes
 
@@ -536,6 +538,7 @@ struct NewBrewSheet: View {
                 notes: resolvedNotes,
                 bag: bag
             )
+            brewCommitted = true
         } catch is QuotaExceededError {
             paywallHeadline = "You've reached the free limit of \(ProQuota.brews) brews. Unlock Pro for unlimited."
             showingPaywall = true
@@ -634,6 +637,7 @@ struct NewBrewSheet: View {
         brewTimeSeconds = preset.brewTimeSeconds
         grindSetting = preset.grindSetting ?? ""
         waterTempC = preset.waterTempC
+        bag = bagStore.pinnedBag
         prefillSnapshot = PrefillSnapshot(
             dose: preset.doseGrams,
             yield: preset.yieldGrams,


### PR DESCRIPTION
## Summary

Two high-confidence bugs in `NewBrewSheet` found during review of recent commits:

**1. Duplicate brew when preset quota fires (data corruption)**

`save()` calls `brewStore.create(...)` first (persists the brew), then — if "Save as recipe" is toggled — calls `brewPresetStore.create(...)`. When that second call throws `QuotaExceededError`, the code set `showingPaywall = true` and returned *without* setting `showSaved = true` or otherwise marking the brew as committed. The sheet stayed open with no feedback. If the user dismissed the paywall and tapped "Save brew" again, a second identical brew was written to the store.

Fix: add a `brewCommitted` flag, set it immediately after `brewStore.create` succeeds, and guard against re-entry at the top of `save()`.

**2. Pinned bag not applied when launching from RecipesView (silent data loss)**

`applyPrefill(from: BrewPreset, jumpToShot:)` set method/dose/yield/time/grind/temp but never set `bag`. Launching `NewBrewSheet(prefillPreset:)` from RecipesView always started with `bag = nil`, silently discarding the pinned bag — every brew from a recipe was saved unlinked.

The `applyPrefill(from: Brew, …)` overload correctly sets `bag = source.bag`. The `BrewPreset` overload now sets `bag = bagStore.pinnedBag`, matching the cold-cold-start fallback already applied at the bottom of `hydrate()`.

## Changes

| File | Change |
|---|---|
| `NewBrewSheet.swift` | Add `@State private var brewCommitted = false`; guard at top of `save()`; set flag after successful `brewStore.create` |
| `NewBrewSheet.swift` | `applyPrefill(from: BrewPreset)`: add `bag = bagStore.pinnedBag` |

## Test plan

- [ ] Build succeeds
- [ ] Free-tier user taps "Save brew" with "Save as recipe" at quota: paywall appears, dismissing paywall does NOT create a second brew
- [ ] Tapping a recipe in RecipesView opens `NewBrewSheet` on Step 1 with the pinned bag pre-selected (not nil)
- [ ] Tapping a recipe with no pinned bag: Step 0 shows no bag selected (bag = nil, same as before)

https://claude.ai/code/session_0121Tvo3k61JK3u6Queco7y7

---
_Generated by [Claude Code](https://claude.ai/code/session_0121Tvo3k61JK3u6Queco7y7)_