### PR TITLE
fix(brews): show saved confirmation when recipe-quota paywall fires mid-save

### DIFF
--- a/BeanBook/Features/Brews/NewBrewSheet.swift
+++ b/BeanBook/Features/Brews/NewBrewSheet.swift
@@ -561,6 +561,7 @@ struct NewBrewSheet: View {
                     waterTempC: waterTempC
                 )
             } catch is QuotaExceededError {
+                withAnimation(.easeOut(duration: 0.25)) { showSaved = true }
                 paywallHeadline = "You've reached the free limit of \(ProQuota.recipes) saved recipes. Unlock Pro for unlimited."
                 showingPaywall = true
                 return


### PR DESCRIPTION
$(cat <<'EOF'
## What this fixes

When `saveAsPreset = true` and the user is on the free tier with recipe quota exhausted, `save()` took this path:

1. `brewStore.create(...)` succeeds → `brewCommitted = true` (brew IS written to disk)
2. `brewPresetStore.create(...)` throws `QuotaExceededError`
3. Paywall shown → **function returns early**
4. `showSaved = true` is **never reached**

Result: the brew was silently saved, but the 1.4 s "Saved." overlay never appeared, the sheet never auto-dismissed, and `brewCommitted = true` permanently disabled the "Save brew" button for that session. The user saw the paywall, dismissed it, and was left staring at the open form with no indication anything happened.

**Fix:** add `withAnimation(.easeOut(duration: 0.25)) { showSaved = true }` at the top of the recipe-quota `catch` block, before triggering the paywall. The brew confirmation now displays for 1.4 s and dismisses the sheet, exactly as on a full success. The paywall sheet appears concurrently; the user can upgrade in a follow-up session to save the recipe.

## Files changed

- `BeanBook/Features/Brews/NewBrewSheet.swift` — one line added in `save()`

## Low-confidence findings (not fixed here — needs design decision)

**"Brew this again" hot-start ignores the pinned bag**

The verifier confirmed this inconsistency. When a user taps "Brew this again" (from `BrewListView` or `BrewDetailView`), `hydrate()` calls `applyPrefill(from brew:)` and returns immediately — no pinned-bag override check. The cold-start path (and the new preset-launch path) both apply the pin override, offering a swap chip when pinned ≠ source bag. The hot-start from an explicit brew does not.

Reproducing: pin Bag B, then tap "Brew this again" on an old brew that used Bag A. Form opens with Bag A selected, no swap chip, Bag B (the pinned preference) silently ignored.

This was not introduced by the recent commits — `applyPrefill(from brew:)` has always set `bag = source.bag`. Whether the pin should win over the explicit brew's bag is a product decision. Leaving it here for review rather than auto-fixing.

## Test plan

- [ ] Free tier, brews remaining, recipe quota exhausted → check "Save as recipe", tap Save → brew saves, "Saved." overlay appears, sheet dismisses, paywall shows concurrently
- [ ] Free tier, both quotas remaining → normal full-success path unaffected
- [ ] Free tier, brew quota exhausted → brew paywall still shows without "Saved." (brew not committed)
- [ ] Pro tier → normal full-success path unaffected

https://claude.ai/code/session_01Bn7BbGTcut66GC8mnpnod2
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bn7BbGTcut66GC8mnpnod2)_