### PR TITLE
Animation fixes: BigRatio count-up, BrewTimer state mutation, DeltaCaption transitions

### DIFF
--- a/BeanBook/Features/Brews/Components/BrewTimer.swift
+++ b/BeanBook/Features/Brews/Components/BrewTimer.swift
@@ -1,10 +1,10 @@
 import SwiftUI
 
 /// Editorial countdown timer — counts down from a target brew duration to zero.
-/// Tap "Start" to begin, "Pause"/"Resume" mid-run, "Reset" to clear. The number
+/// Tap “Start” to begin, “Pause”/“Resume” mid-run, “Reset” to clear. The number
 /// turns forest-accent while running and shifts to success-green on completion.
 struct BrewTimer: View {
-    /// Two-way binding to the brew's planned/elapsed time in seconds.
+    /// Two-way binding to the brew’s planned/elapsed time in seconds.
     /// While idle, this is the **target** the user is brewing toward (adjusted via the ±30s chips).
     /// When paused or finished, it reflects the actual elapsed time.
     @Binding var seconds: Int
@@ -56,7 +56,9 @@ struct BrewTimer: View {
                     }
                     .accessibilityHint(phase == .idle ? "Double tap to set timer duration" : "")
                     .onChange(of: remaining <= 0) { _, finished in
-                        if finished && phase == .running { finish() }
+                        if finished && phase == .running {
+                            DispatchQueue.main.async { finish() }
+                        }
                     }
             }
             .accessibilityLabel(accessibilityTimeLabel)
@@ -257,7 +259,7 @@ struct BrewTimer: View {
             startDate = Date()
             phase = .running
         case .finished:
-            // "Start over" — clear and restart from idle.
+            // “Start over” — clear and restart from idle.
             reset()
         }
     }

--- a/BeanBook/Features/Brews/NewBrewSheet.swift
+++ b/BeanBook/Features/Brews/NewBrewSheet.swift
@@ -17,7 +17,7 @@ struct NewBrewSheet: View {
 
     /// Optional bag to pre-link.
     var initialBag: Bag? = nil
-    /// Optional brew to pre-fill from (for "Brew this again" / Recipe launch).
+    /// Optional brew to pre-fill from (for “Brew this again” / Recipe launch).
     var prefill: Brew? = nil
     /// Optional saved recipe to pre-fill from (for Recipe tab launch).
     var prefillPreset: BrewPreset? = nil
@@ -35,7 +35,7 @@ struct NewBrewSheet: View {
 
     /// Snapshot of the values used to prefill the form. Used to render Δ-from-last hints.
     @State private var prefillSnapshot: PrefillSnapshot?
-    /// The bag whose values were used for prefill — surfaced as a "recent" swap chip if user has a different pinned bag.
+    /// The bag whose values were used for prefill — surfaced as a “recent” swap chip if user has a different pinned bag.
     @State private var recentBag: Bag?
 
     @State private var saveAsPreset = false
@@ -373,6 +373,7 @@ struct NewBrewSheet: View {
                     DeltaCaption(text: cap)
                 }
             }
+            .motion(Motion.control, value: timeCaption != nil)
             .padding(.top, 28)
 
             GrindRow(value: $grindSetting, caption: grindCaption)
@@ -587,7 +588,7 @@ struct NewBrewSheet: View {
         // Cold start. Honor autoPrefillFromLast: hydrate values (and bag) from most recent brew.
         if autoPrefillFromLast, let recent = brewStore.mostRecent() {
             applyPrefill(from: recent, jumpToShot: false)
-            // Pin override: if user has a pinned bag and it's different from recent's bag,
+            // Pin override: if user has a pinned bag and it’s different from recent’s bag,
             // surface pinned as the active selection but keep recent visible as a swap chip.
             if let pinned = bagStore.pinnedBag, pinned.id != recent.bag?.id {
                 recentBag = recent.bag
@@ -694,6 +695,7 @@ private struct StepperRow: View {
                         DeltaCaption(text: caption)
                     }
                 }
+                .motion(Motion.control, value: caption != nil)
                 Spacer()
                 stepper
             }
@@ -807,6 +809,7 @@ private struct GrindRow: View {
                         DeltaCaption(text: caption)
                     }
                 }
+                .motion(Motion.control, value: caption != nil)
                 Spacer()
                 TextField("e.g. 2.4", text: $value)
                     .focused($focused)

--- a/BeanBook/Shared/SharedViews/BigRatio.swift
+++ b/BeanBook/Shared/SharedViews/BigRatio.swift
@@ -38,7 +38,7 @@ struct BigRatio: View {
         }
         .frame(maxWidth: .infinity, alignment: alignment.frameAlignment)
         .onAppear {
-            displayRatio = ratio
+            withMotion(Motion.transition, reduceMotion: reduceMotion) { displayRatio = ratio }
         }
         .onChange(of: ratio) { _, newValue in
             withMotion(Motion.transition, reduceMotion: reduceMotion) { displayRatio = newValue }


### PR DESCRIPTION
## Auto-pushed fixes (high confidence)

Three animation bugs were identified and fixed automatically:

### 1. `BigRatio.swift` — Count-up animation missing on initial display
`.onAppear` assigned `displayRatio = ratio` directly, bypassing the animation system. The count-up only fired on subsequent `.onChange` calls, not when the view first appeared.

**Fix:** Wrapped the assignment in `withMotion(Motion.transition, reduceMotion: reduceMotion) { displayRatio = ratio }`, matching the existing `.onChange` handler.

### 2. `BrewTimer.swift` — State mutation during view update
`finish()` (mutates `accumulated`, `startDate`, `seconds`, `phase`, `hasFinished`) was called synchronously from `.onChange` on a `TimelineView` closure that fires every 0.05s — a classic "state mutation during view update" pattern that can cause runtime warnings or undefined behavior.

**Fix:** Deferred via `DispatchQueue.main.async { finish() }`.

### 3. `NewBrewSheet.swift` — `DeltaCaption` transition is a no-op
`DeltaCaption` declares `.transition(.opacity)` but the three VStacks containing it (`StepperRow`, `GrindRow`, timer section of `shotStep`) had no `.animation` context at the conditional insertion/removal site, so the transition fired instantly.

**Fix:** Added `.motion(Motion.control, value: caption != nil)` to all three VStacks.

---

## Issues NOT auto-fixed (medium/low confidence — needs review)

### 4. `OnboardingView.swift` — `.motion` placement may miss `reduceMotion` suppression (medium confidence)

`.motion(Motion.transition, value: step)` is applied to the outer `ZStack` rather than the inner `Group` that carries `.id(step)` and `.transition(.stepForward)`. The transition works today because `step` mutations go through `withMotion` in the button action handler, which already respects `reduceMotion`. However, any future code path that mutates `step` directly (e.g., deep-linking, automated testing, a reset action) would bypass `reduceMotion` suppression and animate even when the user has requested reduced motion.

**Suggested fix:** Move `.motion(Motion.transition, value: step)` from the outer `ZStack` to the inner `Group`, or alternatively guard the entire transition path through `withMotion`.

Not auto-applied because the current behaviour is correct — this is a latent risk, not a live bug.

### 5. `StarRating.swift` — `.motion` scope too narrow (low confidence)

`.motion(Motion.control, value: rating)` is placed on the `Circle` fill inside the button label rather than on the enclosing `HStack` or button itself. This limits the animation scope to only the fill geometry, potentially clipping transitions that should affect the whole star or the entire row.

**Suggested fix:** Hoist `.motion(Motion.control, value: rating)` to the `HStack` level so all star buttons animate together.

Not auto-applied because the visible behaviour may be intentional (animate only the fill) and the wider-scope fix could change the look-and-feel in ways that need design sign-off.

---
_Generated by [Claude Code](https://claude.ai/code/session_018eajwRvb9KLSCBKU7WPGqo)_