### PR TITLE
fix(stats): correct Dial-in Pro feature description + review notes from commit audit

### DIFF
--- a/BeanBook/Features/Stats/StatsView.swift
+++ b/BeanBook/Features/Stats/StatsView.swift
@@ -69,7 +69,7 @@ struct StatsView: View {
                     StatsProFeatureRow(number: "01", title: "Overview", detail: "Total brews, active bags, favorite method, average rating.")
                     StatsProFeatureRow(number: "02", title: "What's working", detail: "Highest-rated brews, your best bag, best saved recipe.")
                     StatsProFeatureRow(number: "03", title: "By bag", detail: "Brew count, average rating, common ratio, last brewed.")
-                    StatsProFeatureRow(number: "04", title: "Dial-in", detail: "Espresso shot history with grind and rating changes.", showsRule: false)
+                    StatsProFeatureRow(number: "04", title: "Dial-in", detail: "Dose, yield, grind, and rating history for your current bag.", showsRule: false)
                 }
                 .padding(.top, 16)
 


### PR DESCRIPTION
## What this PR does

**Auto-fixed (high confidence):** The Dial-in Pro feature description in the paywall was stale after the motion-cohesion pass (#44) broadened `dialInRows` to show all brew methods.

**Low-confidence issues:** Three findings from a code audit of recent commits that need human judgment to resolve.

---

## Auto-fix: Dial-in description mismatch (`StatsView.swift:72`)

**Root cause:** PR #44 removed the `brew.method == .espresso` filter from `StatsSummary.dialInRows`, so the section now shows all brew methods for the current bag. The Pro paywall teaser still said *"Espresso shot history with grind and rating changes."* — which was false for any non-espresso user with a pinned bag.

**Fix:** Updated description to *"Dose, yield, grind, and rating history for your current bag."* — matches the actual data shown (`DialInRow.detail` = dose→yield / time / grind).

---

## Low-confidence findings for review

### 1. `applyMethodDefaultsIfFresh` guard may be too broad (`NewBrewSheet.swift:642`)

The new guard `guard prefillSnapshot == nil else { return }` was added to prevent prefilled values from being overwritten. But `.onChange(of: method)` at line 229 calls `applyMethodDefaultsIfFresh`, so **if a user hot-starts a recipe and then navigates back to Step 0 and changes the brew method, the new method's defaults are never applied** — they keep the prefilled dose/yield/time from the original method.

**Possible fix:** Only guard against method defaults if the user hasn't yet changed any field from the snapshot (i.e., check whether `prefillSnapshot` still matches current values). Or reset `prefillSnapshot` when the method changes on step 0. Needs a product decision on whether "change method after prefill → keep old values" is the intended UX.

### 2. `ProEntitlement.refreshEntitlements` empty-sequence guard (`ProEntitlement.swift:~130`)

The new `didIterate` flag prevents calling `setPro(false)` when StoreKit returns an empty sequence. This is intentional to avoid wrongly locking out users on a slow iCloud sync. However, it also means a subscriber who just cancelled and then has a brief StoreKit failure could remain marked as Pro indefinitely in that session, until the next successful refresh.

This is an intentional best-effort trade-off, but worth confirming that the `Transaction.updates` listener would eventually correct the state.

### 3. `BrewTimer` — `lowerBound` removed from elapsed paths (`BrewTimer.swift:254`)

`max(lowerBound, Int(accumulated.rounded()))` was simplified to `Int(accumulated.rounded())` in `toggle()` and `commitElapsed()`. This is likely correct (lowerBound should only constrain the *target*, not actual elapsed time), but it means a user who starts the timer and pauses within a second can now save a 0-second or 1-second brew. Confirm this edge case is acceptable.

---

## Test plan
- [ ] Open Stats with a non-espresso bag pinned → confirm Dial-in shows non-espresso brews and paywall description reads correctly
- [ ] Open Stats with an espresso bag pinned → confirm Dial-in still shows espresso brews as before
- [ ] Hot-start a brew from a recipe → go back to step 0 → change method → verify dose/yield/time behavior matches intent

https://claude.ai/code/session_01Xn1zC4Cf7NziPNLYGves3g

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xn1zC4Cf7NziPNLYGves3g)_