### PR TITLE
fix(brews): honor reduceMotion in recipe-quota paywall path

### DIFF
--- a/BeanBook/Features/Brews/NewBrewSheet.swift
+++ b/BeanBook/Features/Brews/NewBrewSheet.swift
@@ -17,7 +17,7 @@ struct NewBrewSheet: View {
 
     /// Optional bag to pre-link.
     var initialBag: Bag? = nil
-    /// Optional brew to pre-fill from (for “Brew this again” / Recipe launch).
+    /// Optional brew to pre-fill from (for "Brew this again" / Recipe launch).
     var prefill: Brew? = nil
     /// Optional saved recipe to pre-fill from (for Recipe tab launch).
     var prefillPreset: BrewPreset? = nil
@@ -35,7 +35,7 @@ struct NewBrewSheet: View {
 
     /// Snapshot of the values used to prefill the form. Used to render Δ-from-last hints.
     @State private var prefillSnapshot: PrefillSnapshot?
-    /// The bag whose values were used for prefill — surfaced as a “recent” swap chip if user has a different pinned bag.
+    /// The bag whose values were used for prefill — surfaced as a "recent" swap chip if user has a different pinned bag.
     @State private var recentBag: Bag?
 
     @State private var saveAsPreset = false
@@ -553,7 +553,7 @@ struct NewBrewSheet: View {
                     waterTempC: waterTempC
                 )
             } catch is QuotaExceededError {
-                withAnimation(.easeOut(duration: 0.25)) { showSaved = true }
+                withMotion(Motion.fade, reduceMotion: reduceMotion) { showSaved = true }
                 paywallHeadline = "You've reached the free limit of \(ProQuota.recipes) saved recipes. Unlock Pro for unlimited."
                 showingPaywall = true
                 return
@@ -589,7 +589,7 @@ struct NewBrewSheet: View {
         // Cold start. Honor autoPrefillFromLast: hydrate values (and bag) from most recent brew.
         if autoPrefillFromLast, let recent = brewStore.mostRecent() {
             applyPrefill(from: recent, jumpToShot: false)
-            // Pin override: if user has a pinned bag and it’s different from recent’s bag,
+            // Pin override: if user has a pinned bag and it's different from recent's bag,
             // surface pinned as the active selection but keep recent visible as a swap chip.
             if let pinned = bagStore.pinnedBag, pinned.id != recent.bag?.id {
                 recentBag = recent.bag


### PR DESCRIPTION
## Summary

- PR #43 added `showSaved = true` in the recipe-quota error path (brew saved, recipe quota hit), which was the right behavior. But it accidentally used the old `withAnimation(.easeOut(duration: 0.25))` literal instead of `withMotion(Motion.fade, reduceMotion:)`, so the overlay animated even when the user had enabled **Reduce Motion** — breaking the accessibility guarantee established by the Motion token pass in PR #44.
- One-line fix: swap the hardcoded call for `withMotion(Motion.fade, reduceMotion: reduceMotion)`, matching the identical call on the happy-path branch three lines below.

## Root cause

The recipe-quota error path was written as new code, not adapted from the happy-path code. The happy-path call `withAnimation(.easeOut(duration: 0.25))` had already been upgraded to `withMotion(Motion.fade, ...)` on the final line of `save()`, but the new error-path copy kept the old literal.

## Test plan

- [ ] Save a brew with "Save as recipe" enabled while at the recipe quota limit → brew-saved overlay fades in, paywall appears concurrently, overlay fades out after 1.4 s, sheet dismisses
- [ ] Repeat with Accessibility → Motion → Reduce Motion **on** → overlay appears instantly (no fade), same dismiss flow

https://claude.ai/code/session_01NGWL8mwnpykMMUq1JTMmWw

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGWL8mwnpykMMUq1JTMmWw)_