### PR TITLE
fix(timer): guard phase in async finish() to prevent spurious .finished state

### DIFF
--- a/BeanBook/Features/Brews/Components/BrewTimer.swift
+++ b/BeanBook/Features/Brews/Components/BrewTimer.swift
@@ -57,7 +57,10 @@ struct BrewTimer: View {
                     .accessibilityHint(phase == .idle ? "Double tap to set timer duration" : "")
                     .onChange(of: remaining <= 0) { _, finished in
                         if finished && phase == .running {
-                            DispatchQueue.main.async { finish() }
+                            DispatchQueue.main.async {
+                                guard phase == .running else { return }
+                                finish()
+                            }
                         }
                     }
             }


### PR DESCRIPTION
## Summary

- **HIGH confidence fix (committed):** `BrewTimer` — re-check `phase == .running` inside the `DispatchQueue.main.async` block. Without this guard, a user tap (Pause) in the ~1 run-loop gap between the `onChange` check and the async block executing would cause `finish()` to fire with `phase == .paused`, forcing the timer to `.finished`, overwriting accumulated time, and triggering the haptic success feedback at the wrong moment.

## What changed

`BrewTimer.swift` lines 58–62: added `guard phase == .running else { return }` inside the deferred async block. The outer `if finished && phase == .running` check is kept as the fast path; the inner guard is the correctness guarantee.

## Low confidence issues (not fixed — needs review)

**`BagStore.pin(_:)` swallows save errors silently**

`try? context.save()` at the end of `pin(_:)` discards any persistence failure. If the save fails (e.g. disk full, corrupt store), the in-memory state is already mutated (all bags unpinned, target bag pinned) but the change is not persisted — so the next launch sees a different single-pin state. Likelihood is very low (SwiftData saves rarely fail for local stores), but the silent failure could lead to confusing state drift.

Options: propagate the error to the call site, or at minimum log it in DEBUG. Not auto-fixed because changing the call signature of `pin(_:)` has UI ripple.

## Test plan
- [ ] Start timer, let it count down to zero — confirm it reaches `.finished` and haptic fires
- [ ] Start timer, tap Pause just as it hits zero — confirm it stays `.paused` (not `.finished`)
- [ ] Resume from paused — confirm timer continues correctly

https://claude.ai/code/session_01Vq58kAT1ebpEnKTKMZppwB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vq58kAT1ebpEnKTKMZppwB)_