### PR TITLE
fix(timer): remove dead accumulated-time compute in finish()

### DIFF
--- a/BeanBook/Features/Brews/Components/BrewTimer.swift
+++ b/BeanBook/Features/Brews/Components/BrewTimer.swift
@@ -265,9 +265,6 @@ struct BrewTimer: View {
     }
 
     private func finish() {
-        if let start = startDate {
-            accumulated += Date().timeIntervalSince(start)
-        }
         startDate = nil
         accumulated = target
         seconds = Int(target.rounded())


### PR DESCRIPTION
## Summary

- **HIGH confidence fix:** `BrewTimer.finish()` — removed dead code block that computed elapsed time only to have it immediately overwritten.

## What changed

`BrewTimer.swift` `finish()` previously did:
```swift
if let start = startDate {
    accumulated += Date().timeIntervalSince(start)  // ← dead
}
startDate = nil
accumulated = target  // ← always overwrites the line above
```

The first block added elapsed-since-last-resume to `accumulated`, but `accumulated = target` on the very next statement unconditionally replaced it. The computed value was always discarded. The intent — snap accumulated to exactly `target` when the countdown hits zero — was already fully expressed by the unconditional assignment.

Removed the dead block. Behaviour is identical; `accumulated` still becomes `target`. The code now states the intent clearly and no longer implies actual elapsed time is being preserved.

## Low confidence issues (not fixed — needs review)

**`BagStore.pin(_:)` swallows save errors silently** (also noted in PR #49)

`try? context.save()` at the end of `pin(_:)` discards any persistence failure. If the save fails, the in-memory state is already mutated (all bags unpinned, target bag pinned) but the change is not persisted — next launch sees a different single-pin state. Likelihood is very low for local SwiftData stores, but the silent failure could cause confusing state drift. Options: propagate the error to the call site, or at minimum log it in DEBUG. Not auto-fixed because changing `pin(_:)`'s signature has UI ripple.

## Test plan
- [ ] Start timer, let it count down to zero — confirm it reaches `.finished`, haptic fires, and the overlay shows the correct target time
- [ ] Start timer, pause partway through, resume, let it reach zero — confirm `.finished` and target time still correct
- [ ] Reset from `.finished` — confirm timer returns to idle with target preserved

https://claude.ai/code/session_01UB7KBfKyRK6ZujTSECgZjX

---
_Generated by [Claude Code](https://claude.ai/code/session_01UB7KBfKyRK6ZujTSECgZjX)_