### PR TITLE
fix(stats): show 30 days in eyebrow to match 30-bar activity chart

### DIFF
--- a/BeanBook/Features/Stats/StatsView.swift
+++ b/BeanBook/Features/Stats/StatsView.swift
@@ -256,7 +256,7 @@ struct StatsView: View {
             return "Stats"
         }
         let start = summary.windowStart.formatted(.dateTime.month(.abbreviated).day())
-        let dayCount = Calendar.current.dateComponents([.day], from: summary.windowStart, to: summary.windowEnd).day ?? 29
+        let dayCount = summary.dailyCounts.count
         return "\(dayCount) days / since \(start)"
     }
 


### PR DESCRIPTION
## Summary

- `statsEyebrow` was computing `dayCount` via `Calendar.dateComponents([.day], from: windowStart, to: windowEnd)`, which returns **29** because `windowStart` is midnight-29-days-ago and `windowEnd` is the current moment — 29 days + some hours, truncating to 29.
- `dailyCounts` always produces **30** entries (offsets `0..<30` from `windowStart`), and `BrewActivityStrip` renders 30 bars.
- The label said "29 days / since May 9" while the chart showed 30 days of data.

**Fix:** Replace the date-components calculation with `summary.dailyCounts.count` so the label always matches the actual chart width.

## Test plan

- [ ] Build and run on simulator
- [ ] Navigate to Stats tab as a Pro user with brews in the last 30 days
- [ ] Confirm the eyebrow reads "30 days / since [date]" and the activity strip has 30 bars

https://claude.ai/code/session_0168dGQCgZCoAuNmRfPnFPP5

---
_Generated by [Claude Code](https://claude.ai/code/session_0168dGQCgZCoAuNmRfPnFPP5)_