### PR TITLE
fix(brew+location): paywall/dismiss race + redundant location requests

### DIFF
--- a/BeanBook/Core/Services/LocationService.swift
+++ b/BeanBook/Core/Services/LocationService.swift
@@ -60,7 +60,12 @@ final class LocationService: NSObject, CLLocationManagerDelegate {
         Task { @MainActor in
             switch status {
             case .authorizedAlways, .authorizedWhenInUse:
-                self.manager.requestLocation()
+                if self.coordinate == nil {
+                    self.status = .requesting
+                    self.manager.requestLocation()
+                } else {
+                    self.status = .ready
+                }
             case .denied, .restricted:
                 self.status = .denied
             case .notDetermined:

--- a/BeanBook/Features/Brews/NewBrewSheet.swift
+++ b/BeanBook/Features/Brews/NewBrewSheet.swift
@@ -96,7 +96,7 @@ struct NewBrewSheet: View {
         .task(id: showSaved) {
             guard showSaved else { return }
             try? await Task.sleep(for: .milliseconds(1400))
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled, !showingPaywall else { return }
             dismiss()
         }
     }
@@ -553,7 +553,6 @@ struct NewBrewSheet: View {
                     waterTempC: waterTempC
                 )
             } catch is QuotaExceededError {
-                withMotion(Motion.fade, reduceMotion: reduceMotion) { showSaved = true }
                 paywallHeadline = "You've reached the free limit of \(ProQuota.recipes) saved recipes. Unlock Pro for unlimited."
                 showingPaywall = true
                 return


### PR DESCRIPTION
## Summary

Three high-confidence bugs found during commit review, each with a narrow, safe fix.

- **`NewBrewSheet` preset quota path sets `showSaved = true` prematurely** — when `brewPresetStore.create()` throws `QuotaExceededError`, the save branch was setting both `showSaved = true` and `showingPaywall = true`. This caused the "Saved." success overlay to flash, the 1.4 s auto-dismiss timer to fire, and the paywall to be torn down with the sheet. The brew *was* saved; only the preset creation failed, so no success feedback should appear.

- **`NewBrewSheet` auto-dismiss doesn't guard against an active paywall** — the `.task(id: showSaved)` dismiss path checked only `!Task.isCancelled`. Adding `!showingPaywall` prevents the 1.4 s sleep from dismissing the sheet while the paywall is presented, regardless of how the state got there.

- **`LocationService.didChangeAuthorization` ignores cached coordinate** — the delegate callback always called `requestLocation()` on an authorized status, bypassing the `coordinate == nil` check that `requestIfNeeded()` correctly enforces. Every app-resume or settings-change event with an authorized status issued a new (unnecessary) location request, wasting battery. The delegate path now mirrors `requestIfNeeded()`.

## Test plan

- [ ] Log a brew with "Save as recipe" checked when at the free recipe quota → should see paywall sheet with no success overlay; sheet stays open until paywall is dismissed or cancelled
- [ ] Log a brew normally → "Saved." overlay appears and sheet auto-dismisses after ~1.4 s
- [ ] Open Shop with location already granted and cached → no second location prompt or request on subsequent visits

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdmpYXqixFCTLmbjYdroT2)_