### PR TITLE
fix(stats): use isDateInToday for activity strip today-bar [needs review]

### DIFF
--- a/BeanBook/Features/Stats/StatsView.swift
+++ b/BeanBook/Features/Stats/StatsView.swift
@@ -368,7 +368,7 @@ private struct BrewActivityStrip: View {
 
             HStack(alignment: .bottom, spacing: 4) {
                 ForEach(days) { day in
-                    let isToday = day.id == days.last?.id
+                    let isToday = Calendar.current.isDateInToday(day.date)
                     RoundedRectangle(cornerRadius: 1.5)
                         .fill(isToday ? Theme.accent : (day.count > 0 ? Theme.ink.opacity(0.82) : Theme.rule))
                         .frame(maxWidth: .infinity)


### PR DESCRIPTION
## Summary

**Low-confidence fix — needs review before merging.**

`BrewActivityStrip` identifies the "today" bar by comparing `day.id == days.last?.id`. This relies on the last element of the `dailyCounts` array always being today. `dailyCounts` is built with `(0..<30).compactMap { ... calendar.date(byAdding: .day, value: offset, to: start) }` — if `calendar.date(byAdding:)` ever returns `nil` for an intermediate offset (unlikely on a real device but possible in extreme edge cases like DST transitions), the last element after `compactMap` might not be today, and the wrong bar gets the accent colour.

**Fix:** Replace the positional comparison with `Calendar.current.isDateInToday(day.date)`, which compares against the actual current date regardless of array position.

**Why "needs review":** The failure scenario is extremely unlikely in practice — `calendar.date(byAdding:)` almost never returns nil for these offsets. This is a correctness improvement but not an actively observed bug.

## Test plan

- [ ] Open Stats tab → confirm the rightmost bar (today) is accent-coloured
- [ ] No visual regression on the activity strip

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdmpYXqixFCTLmbjYdroT2)_