### PR TITLE
fix(brew): complete save flow after preset-quota paywall dismiss

### DIFF
--- a/BeanBook/Features/Brews/NewBrewSheet.swift
+++ b/BeanBook/Features/Brews/NewBrewSheet.swift
@@ -87,7 +87,15 @@ struct NewBrewSheet: View {
                 .navigationBarTitleDisplayMode(.inline)
         }
         .interactiveDismissDisabled(true)
-        .sheet(isPresented: $showingPaywall) {
+        .sheet(isPresented: $showingPaywall, onDismiss: {
+            // Brew quota failure: brewCommitted is still false, nothing to do.
+            // Preset quota failure: brew was already saved but showSaved never fired.
+            // Drive the normal save-completion flow so the success overlay shows and
+            // the sheet dismisses rather than leaving the user stuck with a dead button.
+            if brewCommitted && !showSaved {
+                withMotion(Motion.fade, reduceMotion: reduceMotion) { showSaved = true }
+            }
+        }) {
             NavigationStack {
                 PaywallSheet(headline: paywallHeadline)
             }


### PR DESCRIPTION
## Bug

When `saveAsPreset = true` and the recipe quota is exceeded (brew **was** saved successfully, `brewCommitted = true`), the paywall sheet appeared correctly. But after the user dismissed the paywall, the sheet was **stuck**:

- `brewCommitted = true` → the "Save brew" button silently returned via `guard !brewCommitted`
- `showSaved = false` → the success overlay never appeared and the auto-dismiss task never fired
- The only escape was the "Cancel" button, with no indication the brew had actually been saved

The brew quota failure path (where `brewCommitted` is still `false`) was unaffected — that path correctly leaves the user able to retry after purchasing Pro.

## Fix

Add `onDismiss:` to the paywall `.sheet` modifier. When the paywall is dismissed and `brewCommitted && !showSaved` (preset-quota failure case only), set `showSaved = true`. This drives the existing success-overlay + auto-dismiss flow that `save()` normally triggers at the end of the happy path.

```swift
.sheet(isPresented: $showingPaywall, onDismiss: {
    if brewCommitted && !showSaved {
        withMotion(Motion.fade, reduceMotion: reduceMotion) { showSaved = true }
    }
}) { ... }
```

The existing `.task(id: showSaved)` guard `!showingPaywall` is satisfied at `onDismiss` time (the sheet is already gone), so the 1.4 s dismiss fires correctly.

## Test plan

- [ ] Save brew with `saveAsPreset = true` as a free user at recipe quota → paywall appears
- [ ] Dismiss paywall without purchasing → success overlay appears, sheet dismisses after ~1.4 s, brew is in the list
- [ ] Save brew as a free user at **brew** quota → paywall appears, dismiss → sheet stays open, "Save brew" is still active (brew quota path unchanged)
- [ ] Save brew with `saveAsPreset = true` as Pro user → saves both brew and preset normally, no regression

https://claude.ai/code/session_01DcaFFyKr1izxXyPwuwJru1

---
_Generated by [Claude Code](https://claude.ai/code/session_01DcaFFyKr1izxXyPwuwJru1)_